### PR TITLE
Support saving and loading encrypted data

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ Next, run Apache Spark SQL queries with Opaque as follows, assuming Spark is alr
     // +----+-----+
     ```
 
+6. Save and load an encrypted DataFrame:
+
+    ```scala
+    dfEncrypted.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("dfEncrypted")
+    // The file dfEncrypted/part-00000 now contains encrypted data
+
+    import org.apache.spark.sql.types._
+    val df2 = (spark.read.format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+      .schema(StructType(Seq(StructField("word", StringType), StructField("count", IntegerType))))
+      .load("dfEncrypted"))
+    df2.show
+    // +----+-----+
+    // |word|count|
+    // +----+-----+
+    // | foo|    4|
+    // | bar|    1|
+    // | baz|    5|
+    // +----+-----+
+    ```
+
 ## Contact
 
 If you want to know more about our project or have questions, please contact Wenting (wzheng@eecs.berkeley.edu) and/or Ankur (ankurdave@gmail.com).

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -17,8 +17,10 @@
 
 package edu.berkeley.cs.rise.opaque
 
+import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.UUID
 
 import scala.collection.mutable.ArrayBuilder
 
@@ -158,6 +160,19 @@ object Utils {
         "Error while extracting native library: " + ex)
     }
     extractedPath.toAbsolutePath.toString
+  }
+
+  def createTempDir(): File = {
+    val dir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID.toString)
+    dir.mkdirs()
+    dir.getCanonicalFile
+  }
+
+  def deleteRecursively(file: File): Unit = {
+    for (contents <- Option(file.listFiles); f <- contents) {
+      deleteRecursively(f)
+      f.delete()
+    }
   }
 
   def initEnclave(): (SGXEnclave, Long) = {

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/sources.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/sources.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.berkeley.cs.rise.opaque
 
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/sources.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/sources.scala
@@ -1,0 +1,60 @@
+package edu.berkeley.cs.rise.opaque
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.sources.CreatableRelationProvider
+import org.apache.spark.sql.sources.SchemaRelationProvider
+import org.apache.spark.sql.types.StructType
+
+import edu.berkeley.cs.rise.opaque.execution.Block
+import edu.berkeley.cs.rise.opaque.execution.OpaqueOperatorExec
+
+class EncryptedSource extends SchemaRelationProvider with CreatableRelationProvider {
+  override def createRelation(
+    sqlContext: SQLContext,
+    parameters: Map[String, String],
+    schema: StructType): BaseRelation = {
+    EncryptedScan(parameters("path"), schema, isOblivious(parameters))(
+      sqlContext.sparkSession)
+  }
+
+  override def createRelation(
+    sqlContext: SQLContext,
+    mode: SaveMode,
+    parameters: Map[String, String],
+    data: DataFrame): BaseRelation = {
+    val blocks: RDD[Block] = data.queryExecution.executedPlan.asInstanceOf[OpaqueOperatorExec]
+      .executeBlocked()
+    blocks.map(block => (0, block.bytes)).saveAsSequenceFile(parameters("path"))
+    EncryptedScan(parameters("path"), data.schema, isOblivious(parameters))(
+      sqlContext.sparkSession)
+  }
+
+  private def isOblivious(parameters: Map[String, String]): Boolean = {
+    parameters.get("oblivious") match {
+      case Some("true") => true
+      case _ => false
+    }
+  }
+}
+
+case class EncryptedScan(
+    path: String,
+    override val schema: StructType,
+    val isOblivious: Boolean)(
+    @transient val sparkSession: SparkSession)
+  extends BaseRelation {
+
+  override def sqlContext: SQLContext = sparkSession.sqlContext
+
+  override def needConversion: Boolean = false
+
+  def buildBlockedScan(): RDD[Block] = sparkSession.sparkContext
+    .sequenceFile[Int, Array[Byte]](path).map {
+      case (_, bytes) => Block(bytes)
+    }
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -29,12 +29,17 @@ import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 import edu.berkeley.cs.rise.opaque.execution._
 import edu.berkeley.cs.rise.opaque.logical._
 
 object OpaqueOperators extends Strategy {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+
+    case l @ LogicalRelation(baseRelation: EncryptedScan, _, _) =>
+      EncryptedBlockRDDScanExec(
+        l.output, baseRelation.buildBlockedScan(), baseRelation.isOblivious) :: Nil
 
     case EncryptedProject(projectList, child) =>
       ObliviousProjectExec(projectList, planLater(child)) :: Nil

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,2 +1,3 @@
 log4j.logger.org.apache.spark=WARN
+log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.apache.spark.executor.Executor=ERROR


### PR DESCRIPTION
This PR adds a DataSource that can save and load an encrypted DataFrame as a Hadoop SequenceFile. Usage is added to the README.

Closes #15.