### PR TITLE
Add support to SGX 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ before_install:
   - sudo apt-get install build-essential ocaml automake autoconf libtool
   - export CC=gcc-4.8
   - export CXX=g++-4.8
-  - git clone https://github.com/ankurdave/linux-sgx -b c++11
-  - cd linux-sgx
+  - git clone https://github.com/intel/linux-sgx.git tags/sgx_2.0
+  - cd tags/sgx_2.0
   - ./download_prebuilt.sh
   - make --quiet sdk_install_pkg
-  - cd ..
-  - echo yes | ./linux-sgx/linux/installer/bin/sgx_linux_x64_sdk_*.bin
+  - echo yes | ./linux/installer/bin/sgx_linux_x64_sdk_*.bin
   - source sgxsdk/environment
+  - cd ../..
   - openssl ecparam -name prime256v1 -genkey -noout -out private_key.pem
   - export SPARKSGX_DATA_DIR=$PWD/data
   - export PRIVATE_KEY_PATH=$PWD/private_key.pem

--- a/src/enclave/Enclave/CMakeLists.txt
+++ b/src/enclave/Enclave/CMakeLists.txt
@@ -28,7 +28,7 @@ add_custom_command(
   DEPENDS ../ServiceProvider/keygen
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/key.cpp)
 
-include_directories(SYSTEM "$ENV{SGX_SDK}/include/stlport")
+include_directories(SYSTEM "$ENV{SGX_SDK}/include/libcxx")
 include_directories(SYSTEM "$ENV{SGX_SDK}/include/tlibc")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -nostdinc -fvisibility=hidden -fpie -fstack-protector")
@@ -42,7 +42,7 @@ set_target_properties(enclave_trusted PROPERTIES LINK_FLAGS ${ENCLAVE_LINK_FLAGS
 find_library(TRTS_LIB sgx_trts)
 find_library(TRTS_SIM_LIB sgx_trts_sim)
 find_library(TSTDC_LIB sgx_tstdc)
-find_library(TSTDCXX_LIB sgx_tstdcxx)
+find_library(TSTDCXX_LIB sgx_tcxx)
 find_library(TKEY_EXCHANGE_LIB sgx_tkey_exchange)
 find_library(TCRYPTO_LIB sgx_tcrypto)
 find_library(SERVICE_LIB sgx_tservice)


### PR DESCRIPTION
Makefile adjustment to enable Opaque to run with SGX2.0
Tested with "Big Data Benchmark" suite on Linux SGX 2.0 sdk environment