### PR TITLE
Handle partitions with zero blocks in ObliviousUnionExec

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
@@ -337,9 +337,11 @@ case class ObliviousUnionExec(
     // RA.initRA(leftRDD)
 
     val unioned = leftRDD.zipPartitions(rightRDD) { (leftBlockIter, rightBlockIter) =>
-      (leftBlockIter.toSeq, rightBlockIter.toSeq) match {
-        case (Seq(leftBlock), Seq(rightBlock)) =>
+      (leftBlockIter.toSeq ++ rightBlockIter.toSeq) match {
+        case Seq(leftBlock, rightBlock) =>
           Iterator(Utils.concatEncryptedBlocks(Seq(leftBlock, rightBlock)))
+        case Seq(block) => Iterator(block)
+        case Seq() => Iterator.empty
       }
     }
     Utils.ensureCached(unioned)

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -330,6 +330,7 @@ class OpaqueMultiplePartitionSuite extends OpaqueOperatorTests {
     .master("local[1]")
     .appName("QEDSuite")
     .config("spark.sql.shuffle.partitions", 3)
+    .config("spark.default.parallelism", 3)
     .getOrCreate()
 
   override def numPartitions = 3


### PR DESCRIPTION
When an RDD has more partitions than the encrypted blocks in a dataset, such as when `sc.defaultParallelism` is greater than the number of blocks, some partitions may be empty. ObliviousUnionExec currently fails to handle this case and crashes with a MatchError. This PR handles empty partitions in ObliviousUnionExec. Fixes #28.