### PR TITLE
Remove references to obliviousness from operator names

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/sources.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/sources.scala
@@ -35,7 +35,7 @@ class EncryptedSource extends SchemaRelationProvider with CreatableRelationProvi
     sqlContext: SQLContext,
     parameters: Map[String, String],
     schema: StructType): BaseRelation = {
-    EncryptedScan(parameters("path"), schema, isOblivious(parameters))(
+    EncryptedScan(parameters("path"), schema)(
       sqlContext.sparkSession)
   }
 
@@ -47,22 +47,14 @@ class EncryptedSource extends SchemaRelationProvider with CreatableRelationProvi
     val blocks: RDD[Block] = data.queryExecution.executedPlan.asInstanceOf[OpaqueOperatorExec]
       .executeBlocked()
     blocks.map(block => (0, block.bytes)).saveAsSequenceFile(parameters("path"))
-    EncryptedScan(parameters("path"), data.schema, isOblivious(parameters))(
+    EncryptedScan(parameters("path"), data.schema)(
       sqlContext.sparkSession)
-  }
-
-  private def isOblivious(parameters: Map[String, String]): Boolean = {
-    parameters.get("oblivious") match {
-      case Some("true") => true
-      case _ => false
-    }
   }
 }
 
 case class EncryptedScan(
     path: String,
-    override val schema: StructType,
-    val isOblivious: Boolean)(
+    override val schema: StructType)(
     @transient val sparkSession: SparkSession)
   extends BaseRelation {
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -36,10 +36,10 @@ import edu.berkeley.cs.rise.opaque.logical._
 object OpaqueOperators extends Strategy {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case EncryptedProject(projectList, child) =>
-      ObliviousProjectExec(projectList, planLater(child)) :: Nil
+      EncryptedProjectExec(projectList, planLater(child)) :: Nil
 
     case EncryptedFilter(condition, child) =>
-      ObliviousFilterExec(condition, planLater(child)) :: Nil
+      EncryptedFilterExec(condition, planLater(child)) :: Nil
 
     case EncryptedSort(order, child) =>
       EncryptedSortExec(order, planLater(child)) :: Nil
@@ -49,9 +49,9 @@ object OpaqueOperators extends Strategy {
         case ExtractEquiJoinKeys(_, leftKeys, rightKeys, condition, _, _) =>
           val (leftProjSchema, leftKeysProj, tag) = tagForJoin(leftKeys, left.output, true)
           val (rightProjSchema, rightKeysProj, _) = tagForJoin(rightKeys, right.output, false)
-          val leftProj = ObliviousProjectExec(leftProjSchema, planLater(left))
-          val rightProj = ObliviousProjectExec(rightProjSchema, planLater(right))
-          val unioned = ObliviousUnionExec(leftProj, rightProj)
+          val leftProj = EncryptedProjectExec(leftProjSchema, planLater(left))
+          val rightProj = EncryptedProjectExec(rightProjSchema, planLater(right))
+          val unioned = EncryptedUnionExec(leftProj, rightProj)
           val sorted = EncryptedSortExec(sortForJoin(leftKeysProj, tag, unioned.output), unioned)
           val joined = EncryptedSortMergeJoinExec(
             joinType,
@@ -61,24 +61,24 @@ object OpaqueOperators extends Strategy {
             rightProjSchema.map(_.toAttribute),
             (leftProjSchema ++ rightProjSchema).map(_.toAttribute),
             sorted)
-          ObliviousProjectExec(dropTags(left.output, right.output), joined) :: Nil
+          EncryptedProjectExec(dropTags(left.output, right.output), joined) :: Nil
         case _ => Nil
       }
 
     case a @ EncryptedAggregate(groupingExpressions, aggExpressions, child) =>
       EncryptedAggregateExec(groupingExpressions, aggExpressions, planLater(child)) :: Nil
 
-    case ObliviousUnion(left, right) =>
-      ObliviousUnionExec(planLater(left), planLater(right)) :: Nil
+    case EncryptedUnion(left, right) =>
+      EncryptedUnionExec(planLater(left), planLater(right)) :: Nil
 
-    case Encrypt(isOblivious, child) =>
-      EncryptExec(isOblivious, planLater(child)) :: Nil
+    case Encrypt(child) =>
+      EncryptExec(planLater(child)) :: Nil
 
-    case EncryptedLocalRelation(output, plaintextData, isOblivious) =>
-      EncryptedLocalTableScanExec(output, plaintextData, isOblivious) :: Nil
+    case EncryptedLocalRelation(output, plaintextData) =>
+      EncryptedLocalTableScanExec(output, plaintextData) :: Nil
 
-    case EncryptedBlockRDD(output, rdd, isOblivious) =>
-      EncryptedBlockRDDScanExec(output, rdd, isOblivious) :: Nil
+    case EncryptedBlockRDD(output, rdd) =>
+      EncryptedBlockRDDScanExec(output, rdd) :: Nil
 
     case _ => Nil
   }

--- a/src/main/scala/org/apache/spark/sql/OpaqueDatasetFunctions.scala
+++ b/src/main/scala/org/apache/spark/sql/OpaqueDatasetFunctions.scala
@@ -21,6 +21,6 @@ import edu.berkeley.cs.rise.opaque.logical.Encrypt
 
 class OpaqueDatasetFunctions[T](ds: Dataset[T]) extends Serializable {
   def encrypted(): DataFrame = {
-    Dataset.ofRows(ds.sparkSession, Encrypt(false, ds.logicalPlan))
+    Dataset.ofRows(ds.sparkSession, Encrypt(ds.logicalPlan))
   }
 }


### PR DESCRIPTION
This makes the output of `df.explain()` more understandable to new users.