### PR TITLE
Use SGX SDK 2.3 for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install build-essential ocaml automake autoconf libtool
   - export CC=gcc-4.8
   - export CXX=g++-4.8
-  - git clone https://github.com/intel/linux-sgx.git -b sgx_2.1.3
+  - git clone https://github.com/intel/linux-sgx.git -b sgx_2.3
   - cd linux-sgx
   - ./download_prebuilt.sh
   - make --quiet sdk_install_pkg


### PR DESCRIPTION
This is a forgotten change from #42 (23e1cd9ab8510ac19864211496d623d0da60f4d3).