### PR TITLE
Support for serialization of composite types

### DIFF
--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -250,6 +250,22 @@ private:
           tuix::CreateStringFieldDirect(builder, &str_vec, str_vec.size()).Union(),
           result_is_null);
       }
+      case tuix::FieldUnion_MapField:
+      {
+        if (cast->target_type() != tuix::ColType_StringType) {
+          printf("Can't cast Array to %s, only StringType\n",
+               tuix::EnumNameColType(cast->target_type()));
+          std::exit(1);
+        }
+        auto map_field = static_cast<const tuix::MapField *>(value->value());
+        std::string str = to_string(map_field);
+        std::vector<uint8_t> str_vec(str.begin(), str.end());
+        return tuix::CreateField(
+          builder,
+          tuix::FieldUnion_StringField,
+          tuix::CreateStringFieldDirect(builder, &str_vec, str_vec.size()).Union(),
+          result_is_null);
+      }
       default:
       {
         printf("Can't evaluate cast on %s\n",

--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -234,6 +234,10 @@ private:
       {
         return flatbuffers_cast<tuix::DateField, Date>(cast, value, builder, result_is_null);
       }
+      case tuix::FieldUnion_ArrayField:
+      {
+        return flatbuffers_cast<tuix::ArrayField, Array>(cast, value, builder, result_is_null);
+      }
       default:
       {
         printf("Can't evaluate cast on %s\n",

--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -236,7 +236,19 @@ private:
       }
       case tuix::FieldUnion_ArrayField:
       {
-        return flatbuffers_cast<tuix::ArrayField, Array>(cast, value, builder, result_is_null);
+        if (cast->target_type() != tuix::ColType_StringType) {
+          printf("Can't cast Array to %s, only StringType\n",
+               tuix::EnumNameColType(cast->target_type()));
+          std::exit(1);
+        }
+        auto array_field = static_cast<const tuix::ArrayField *>(value->value());
+        std::string str = to_string(array_field);
+        std::vector<uint8_t> str_vec(str.begin(), str.end());
+        return tuix::CreateField(
+          builder,
+          tuix::FieldUnion_StringField,
+          tuix::CreateStringFieldDirect(builder, &str_vec, str_vec.size()).Union(),
+          result_is_null);
       }
       default:
       {

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -147,13 +147,13 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
       is_null);
   case tuix::FieldUnion_ArrayField:
   {
-    auto string_field = static_cast<const tuix::ArrrayField *>(field->value());
+    auto array_field = static_cast<const tuix::ArrayField *>(field->value());
     std::vector<uint8_t> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,
-      tuix::CreateStringFieldDirect(
+      tuix::CreateArrayFieldDirect(
         builder, &array_data, array_field->length()).Union(),
       is_null);
   }

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), 
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(0, 
       5);
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<const tuix::Field> array_data(array_field->value()->begin(),
+    std::vector<flatbuffers::Offset<tuix::Field> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -154,7 +154,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
       builder,
       tuix::FieldUnion_ArrayField,
       tuix::CreateArrayFieldDirect(
-        builder, &array_data, array_field->length()).Union(),
+        builder, &array_data),
       is_null);
   }
   default:

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    array_field->value()
+    array_field->value();
     std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<const tuix::ArrayField> array_data(array_field->value()->begin(),
+    std::vector<const tuix::Field> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<uint8_t> array_data(array_field->value()->begin(), array_field->value()->end());
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -154,7 +154,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
       builder,
       tuix::FieldUnion_ArrayField,
       tuix::CreateArrayFieldDirect(
-        builder, &array_data),
+        builder, &array_data).Union(),
       is_null);
   }
   default:

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,9 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    array_field->value()->begin();
-    array_field->value()->end();
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
+    std::vector<uint8_t> array_data(array_field->value()->begin(), array_field->value()->end());
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -145,18 +145,18 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
         builder,
         static_cast<const tuix::DateField *>(field->value())->value()).Union(),
       is_null);
-  // case tuix::FieldUnion_ArrayField:
-  // {
-  //   auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-  //   std::vector<uint8_t> array_data(array_field->value()->begin(),
-  //                                    array_field->value()->end());
-  //   return tuix::CreateField(
-  //     builder,
-  //     tuix::FieldUnion_ArrayField,
-  //     tuix::CreateArrayFieldDirect(
-  //       builder, &array_data),
-  //     is_null);
-  // }
+  case tuix::FieldUnion_ArrayField:
+  {
+    auto array_field = static_cast<const tuix::ArrayField *>(field->value());
+    std::vector<uint8_t> array_data(array_field->value()->begin(),
+                                     array_field->value()->end());
+    return tuix::CreateField(
+      builder,
+      tuix::FieldUnion_ArrayField,
+      tuix::CreateArrayFieldDirect(
+        builder, &array_data),
+      is_null);
+  }
   default:
     printf("flatbuffers_copy tuix::Field: Unknown field type %d\n",
            field->value_type());

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<void>> array_data(array_field->value()->begin(),
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(),
+    std::vector<flatbuffers::Offset<void>> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field> array_data(array_field->value()->begin(),
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,8 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    array_field->value();
+    array_field->value()->begin();
+    array_field->value()->end();
     std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(),
+    std::vector<const tuix::ArrayField> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,8 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(),
-                                     array_field->value()->end());
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -145,18 +145,18 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
         builder,
         static_cast<const tuix::DateField *>(field->value())->value()).Union(),
       is_null);
-  case tuix::FieldUnion_ArrayField:
-  {
-    auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<uint8_t> array_data(array_field->value()->begin(),
-                                     array_field->value()->end());
-    return tuix::CreateField(
-      builder,
-      tuix::FieldUnion_ArrayField,
-      tuix::CreateArrayFieldDirect(
-        builder, &array_data),
-      is_null);
-  }
+  // case tuix::FieldUnion_ArrayField:
+  // {
+  //   auto array_field = static_cast<const tuix::ArrayField *>(field->value());
+  //   std::vector<uint8_t> array_data(array_field->value()->begin(),
+  //                                    array_field->value()->end());
+  //   return tuix::CreateField(
+  //     builder,
+  //     tuix::FieldUnion_ArrayField,
+  //     tuix::CreateArrayFieldDirect(
+  //       builder, &array_data),
+  //     is_null);
+  // }
   default:
     printf("flatbuffers_copy tuix::Field: Unknown field type %d\n",
            field->value_type());

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -259,6 +259,24 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
         builder, &copied_fields).Union(),
       is_null);
   }
+  case tuix::FieldUnion_MapField:
+  {
+    auto map_field = static_cast<const tuix::MapField *>(field->value());
+    std::vector<flatbuffers::Offset<tuix::Field>> copied_key_fields;
+    std::vector<flatbuffers::Offset<tuix::Field>> copied_value_fields;
+    for (auto f : *map_field->keys()) {
+      copied_key_fields.push_back(flatbuffers_copy(f, builder, false));
+    }
+    for (auto f: *map_field->values()) {
+       copied_value_fields.push_back(flatbuffers_copy(f, builder, false));
+    }
+    return tuix::CreateField(
+      builder,
+      tuix::FieldUnion_MapField,
+      tuix::CreateMapFieldDirect(
+        builder, &copied_key_fields, &copied_value_fields).Union(),
+      is_null);
+  }
   default:
     printf("flatbuffers_copy tuix::Field: Unknown field type %d\n",
            field->value_type());

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -145,6 +145,18 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
         builder,
         static_cast<const tuix::DateField *>(field->value())->value()).Union(),
       is_null);
+  case tuix::FieldUnion_ArrayField:
+  {
+    auto string_field = static_cast<const tuix::ArrrayField *>(field->value());
+    std::vector<uint8_t> array_data(array_field->value()->begin(),
+                                     array_field->value()->end());
+    return tuix::CreateField(
+      builder,
+      tuix::FieldUnion_ArrayField,
+      tuix::CreateStringFieldDirect(
+        builder, &array_data, array_field->length()).Union(),
+      is_null);
+  }
   default:
     printf("flatbuffers_copy tuix::Field: Unknown field type %d\n",
            field->value_type());

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,7 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<uint8_t> array_data(array_field->value()->begin(),
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(),
                                      array_field->value()->end());
     return tuix::CreateField(
       builder,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,8 +148,8 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(std::ref(array_field->value()->begin()), 
-      std::ref(array_field->value()->end()));
+    array_field->value()
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,8 +148,8 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(0, 
-      5);
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(std::ref(array_field->value()->begin()), 
+      std::ref(array_field->value()->end()));
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -148,7 +148,8 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), array_field->value()->end());
+    std::vector<flatbuffers::Offset<tuix::Field>> array_data(array_field->value()->begin(), 
+      5);
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -12,6 +12,144 @@ std::string to_string(const Date &date) {
   return std::string(buffer);
 }
 
+std::string to_string(const tuix::Field *f) {
+  if (f->is_null()) {
+    return "null";
+  }
+   switch (f->value_type()) {
+  case tuix::FieldUnion_BooleanField:
+    return to_string(f->value_as_BooleanField());
+  case tuix::FieldUnion_IntegerField:
+    return to_string(f->value_as_IntegerField());
+  case tuix::FieldUnion_LongField:
+    return to_string(f->value_as_LongField());
+  case tuix::FieldUnion_FloatField:
+    return to_string(f->value_as_FloatField());
+  case tuix::FieldUnion_DoubleField:
+    return to_string(f->value_as_DoubleField());
+  case tuix::FieldUnion_StringField:
+    return to_string(f->value_as_StringField());
+  case tuix::FieldUnion_DateField:
+    return to_string(f->value_as_DateField());
+  case tuix::FieldUnion_BinaryField:
+    return to_string(f->value_as_BinaryField());
+  case tuix::FieldUnion_ByteField:
+    return to_string(f->value_as_ByteField());
+  case tuix::FieldUnion_CalendarIntervalField:
+    return to_string(f->value_as_CalendarIntervalField());
+  case tuix::FieldUnion_NullField:
+    return to_string(f->value_as_NullField());
+  case tuix::FieldUnion_ShortField:
+    return to_string(f->value_as_ShortField());
+  case tuix::FieldUnion_TimestampField:
+    return to_string(f->value_as_TimestampField());
+  case tuix::FieldUnion_ArrayField:
+    return to_string(f->value_as_ArrayField());
+  case tuix::FieldUnion_MapField:
+    return to_string(f->value_as_MapField());
+   default:
+    printf("to_string(tuix::Field): Unknown field type %d\n",
+           f->value_type());
+    std::exit(1);
+    return "";
+  }
+}
+
+std::string to_string(const tuix::BooleanField *f) {
+  return std::to_string(f->value());
+}
+
+std::string to_string(const tuix::IntegerField *f) {
+  return std::to_string(f->value());
+}
+
+std::string to_string(const tuix::LongField *f) {
+  return std::to_string(f->value());
+}
+
+std::string to_string(const tuix::FloatField *f) {
+  return std::to_string(f->value());
+}
+
+std::string to_string(const tuix::DoubleField *f) {
+  return std::to_string(f->value());
+}
+
+std::string to_string(const tuix::StringField *f) {
+  return std::string(f->value()->begin(), f->value()->end());
+}
+
+std::string to_string(const tuix::DateField *f) {
+  return to_string(Date(f->value()));
+}
+
+std::string to_string(const tuix::BinaryField *f) {
+  std::string s;
+  for (uint8_t byte : *f->value()) {
+    s.append(string_format("%02X", byte));
+  }
+  return s;
+}
+
+ std::string to_string(const tuix::ByteField *f) {
+  std::string s;
+  s.append(string_format("%02X", f->value()));
+  return s;
+}
+
+ std::string to_string(const tuix::CalendarIntervalField *f) {
+  (void)f;
+  throw "Can't convert CalendarIntervalField to string";
+}
+
+std::string to_string(const tuix::NullField *f) {
+  (void)f;
+  return "null";
+}
+
+std::string to_string(const tuix::ShortField *f) {
+  return std::to_string(f->value());
+}
+
+ std::string to_string(const tuix::TimestampField *f) {
+  // TODO: Support fractional seconds to mimic the behavior of java.sql.Timestamp#toString
+  uint64_t secs = f->value() / 1000;
+  struct tm tm;
+  secs_to_tm(secs, &tm);
+  char buffer[80];
+  strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm);
+  return std::string(buffer);
+}
+ std::string to_string(const tuix::ArrayField *f) {
+  std::string s;
+  s.append("[");
+  bool first = true;
+  for (auto field : *f->value()) {
+    if (!first) {
+      s.append(", ");
+    }
+    first = false;
+    s.append(to_string(field));
+  }
+  s.append("]");
+  return s;
+}
+ std::string to_string(const tuix::MapField *f) {
+  std::string s;
+  s.append("{");
+  for (uint32_t i = 0; i < f->keys()->size(); ++i) {
+    if (i != 0) {
+      s.append(", ");
+    }
+
+    s.append(to_string(f->keys()->Get(i)));
+    s.append(": ");
+    s.append(to_string(f->values()->Get(i)));
+  }
+  s.append("}");
+  return s;
+}
+
 void print(const tuix::Row *in) {
   flatbuffers::uoffset_t num_fields = in->field_values()->size();
   printf("[");
@@ -25,45 +163,7 @@ void print(const tuix::Row *in) {
 }
 
 void print(const tuix::Field *field) {
-  if (field->is_null()) {
-    printf("null");
-  } else {
-    switch (field->value_type()) {
-    case tuix::FieldUnion_BooleanField:
-      printf("%s",
-             static_cast<const tuix::BooleanField *>(field->value())->value() ? "true" : "false");
-      break;
-    case tuix::FieldUnion_IntegerField:
-      printf("%d", static_cast<const tuix::IntegerField *>(field->value())->value());
-      break;
-    case tuix::FieldUnion_LongField:
-      printf("%ld", static_cast<const tuix::LongField *>(field->value())->value());
-      break;
-    case tuix::FieldUnion_FloatField:
-      printf("%f", static_cast<const tuix::FloatField *>(field->value())->value());
-      break;
-    case tuix::FieldUnion_DoubleField:
-      printf("%lf", static_cast<const tuix::DoubleField *>(field->value())->value());
-      break;
-    case tuix::FieldUnion_StringField:
-    {
-      auto string_field = static_cast<const tuix::StringField *>(field->value());
-      printf("%s",
-             std::string(reinterpret_cast<const char *>(string_field->value()->data()),
-                         string_field->length()).c_str());
-      break;
-    }
-    case tuix::FieldUnion_DateField:
-      printf("%s", to_string(Date(static_cast<const tuix::DateField *>(field->value())->value()))
-             .c_str());
-      break;
-    default:
-      printf("print(tuix::Row *): Unknown field type %d\n",
-             field->value_type());
-      std::exit(1);
-    }
-  }
-
+  ocall_print_string(to_string(field).c_str());
 }
 
 template<>
@@ -148,13 +248,15 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());
-    auto copied_array_offset = builder.CreateVector(array_field->value()->data(),
-                                                    array_field->value()->size());
+    std::vector<flatbuffers::Offset<tuix::Field>> copied_fields;
+    for (auto f : *array_field->value()) {
+      copied_fields.push_back(flatbuffers_copy(f, builder, false));
+    }
     return tuix::CreateField(
       builder,
       tuix::FieldUnion_ArrayField,
-      tuix::CreateArrayField(
-        builder, copied_array_offset).Union(),
+      tuix::CreateArrayFieldDirect(
+        builder, &copied_fields).Union(),
       is_null);
   }
   default:

--- a/src/enclave/Enclave/Flatbuffers.h
+++ b/src/enclave/Enclave/Flatbuffers.h
@@ -91,6 +91,18 @@ flatbuffers::Offset<tuix::Field> flatbuffers_cast(
       tuix::CreateStringFieldDirect(builder, &str_vec, str_vec.size()).Union(),
       result_is_null);
   }
+  case tuix::ColType_ArrayType:
+  {
+    auto array_field = static_cast<const tuix::ArrayField *>(value_eval);
+    auto copied_array_offset = builder.CreateVector(array_field->value()->data(),
+                                                    array_field->value()->size());
+    return tuix::CreateField(
+      builder,
+      tuix::FieldUnion_ArrayField,
+      tuix::CreateArrayField(
+        builder, copied_array_offset).Union(),
+      is_null);
+  }
   default:
   {
     printf("Can't cast %s to %s\n",

--- a/src/enclave/Enclave/Flatbuffers.h
+++ b/src/enclave/Enclave/Flatbuffers.h
@@ -109,18 +109,6 @@ flatbuffers::Offset<tuix::Field> flatbuffers_cast(
       tuix::CreateStringFieldDirect(builder, &str_vec, str_vec.size()).Union(),
       result_is_null);
   }
-  case tuix::ColType_ArrayType:
-  {
-    auto array_field = static_cast<const tuix::ArrayField *>(value_eval);
-    auto copied_array_offset = builder.CreateVector(array_field->value()->data(),
-                                                    array_field->value()->size());
-    return tuix::CreateField(
-      builder,
-      tuix::FieldUnion_ArrayField,
-      tuix::CreateArrayField(
-        builder, copied_array_offset).Union(),
-      is_null);
-  }
   default:
   {
     printf("Can't cast %s to %s\n",

--- a/src/enclave/Enclave/Flatbuffers.h
+++ b/src/enclave/Enclave/Flatbuffers.h
@@ -18,6 +18,7 @@
 
 using namespace edu::berkeley::cs::rise::opaque;
 
+/** Wrapper around a date that provides conversions to various types. */
 class Date {
 public:
   Date(const int32_t &days_since_epoch) : days_since_epoch(days_since_epoch) {}
@@ -31,6 +32,22 @@ public:
 };
 
 std::string to_string(const Date &date);
+std::string to_string(const tuix::Field *f);
+std::string to_string(const tuix::BooleanField *f);
+std::string to_string(const tuix::IntegerField *f);
+std::string to_string(const tuix::LongField *f);
+std::string to_string(const tuix::FloatField *f);
+std::string to_string(const tuix::DoubleField *f);
+std::string to_string(const tuix::StringField *f);
+std::string to_string(const tuix::DateField *f);
+std::string to_string(const tuix::BinaryField *f);
+std::string to_string(const tuix::ByteField *f);
+std::string to_string(const tuix::CalendarIntervalField *f);
+std::string to_string(const tuix::NullField *f);
+std::string to_string(const tuix::ShortField *f);
+std::string to_string(const tuix::TimestampField *f);
+std::string to_string(const tuix::ArrayField *f);
+std::string to_string(const tuix::MapField *f);
 
 template<typename T>
 flatbuffers::Offset<T> flatbuffers_copy(
@@ -42,6 +59,7 @@ template<>
 flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   const tuix::Field *field, flatbuffers::FlatBufferBuilder& builder, bool force_null);
 
+/** Helper function for casting among primitive types and strings. */
 template<typename InputTuixField, typename InputType>
 flatbuffers::Offset<tuix::Field> flatbuffers_cast(
   const tuix::Cast *cast, const tuix::Field *value, flatbuffers::FlatBufferBuilder& builder,

--- a/src/enclave/Enclave/util.cpp
+++ b/src/enclave/Enclave/util.cpp
@@ -15,6 +15,25 @@ int printf(const char *fmt, ...) {
   return ret;
 }
 
+/** From https://stackoverflow.com/a/8362718 */
+std::string string_format(const std::string &fmt, ...) {
+    int size=BUFSIZ;
+    std::string str;
+    va_list ap;
+     while (1) {
+        str.resize(size);
+        va_start(ap, fmt);
+        int n = vsnprintf(&str[0], size, fmt.c_str(), ap);
+        va_end(ap);
+         if (n > -1 && n < size)
+            return str;
+        if (n > -1)
+            size = n + 1;
+        else
+            size *= 2;
+    }
+}
+
 void exit(int exit_code) {
   ocall_exit(exit_code);
 }

--- a/src/enclave/Enclave/util.h
+++ b/src/enclave/Enclave/util.h
@@ -4,6 +4,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <ctime>
+#include <string>
 
 /*
  * printf:
@@ -16,6 +17,8 @@ void exit(int exit_code);
 namespace std {
     using ::exit;
 }
+
+std::string string_format(const std::string &fmt, ...);
 
 void print_bytes(uint8_t *ptr, uint32_t len);
 

--- a/src/flatbuffers/Rows.fbs
+++ b/src/flatbuffers/Rows.fbs
@@ -97,6 +97,7 @@ table Rows {
 
 table ArrayField {
     value:[Field];
+    length: uint;
 }
 
 table MapField {

--- a/src/flatbuffers/Rows.fbs
+++ b/src/flatbuffers/Rows.fbs
@@ -97,7 +97,6 @@ table Rows {
 
 table ArrayField {
     value:[Field];
-    length: long;
 }
 
 table MapField {

--- a/src/flatbuffers/Rows.fbs
+++ b/src/flatbuffers/Rows.fbs
@@ -97,6 +97,7 @@ table Rows {
 
 table ArrayField {
     value:[Field];
+    length: long;
 }
 
 table MapField {

--- a/src/flatbuffers/Rows.fbs
+++ b/src/flatbuffers/Rows.fbs
@@ -97,7 +97,6 @@ table Rows {
 
 table ArrayField {
     value:[Field];
-    length: uint;
 }
 
 table MapField {

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -537,7 +537,7 @@ object Utils {
           val mapField = f.value(new tuix.MapField).asInstanceOf[tuix.MapField]
           var map = Map[Any, Any]()
           for (i <- 0 until mapField.keysLength) {
-            map(flatbuffersExtractFieldValue(mapField.keys(i))) = flatbuffersExtractFieldValue(mapField.values(i))
+            map += ((flatbuffersExtractFieldValue(mapField.keys(i))) -> flatbuffersExtractFieldValue(mapField.values(i)))
           }
           map
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -433,8 +433,7 @@ object Utils {
       case (x: MapData, MapType(keyType, valueType, valueContainsNull)) =>
         var keys = new ArrayBuilder.ofInt()
         var values = new ArrayBuilder.ofInt()
-        for (k <- x.keys) {
-          val v = x(k)
+        for ((k, v) <- x) {
           keys += flatbuffersCreateField(builder, k, keyType, isNull)
           values += flatbuffersCreateField(builder, v, valueType, isNull)
         } 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -453,7 +453,7 @@ object Utils {
           tuix.FieldUnion.MapField,
           tuix.MapField.createMapField(
             builder,
-            tuix.MapField.createKeysVector(builder, Array.empty)
+            tuix.MapField.createKeysVector(builder, Array.empty),
             tuix.MapField.createValuesVector(builder, Array.empty)),
           isNull)
       case (s: UTF8String, StringType) =>

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -530,7 +530,7 @@ object Utils {
                 null
               }
           }
-          // ArrayData.toArrayData(arr)
+          ArrayData.toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -80,12 +80,6 @@ import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeArrayData}
-import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.Platform
-import org.apache.spark.unsafe.array.ByteArrayMethods
-
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
@@ -530,22 +524,11 @@ object Utils {
           for (i <- 0 until arrField.valueLength) {
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
-          toArrayData(arr)
+          ArrayData.array(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }
     }
-  }
-
-  def toArrayData(input: Any): ArrayData = input match {
-    case a: Array[Boolean] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Byte] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Short] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Int] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Long] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Float] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Double] => UnsafeArrayData.fromPrimitiveArray(a)
-    case other => new GenericArrayData(other)
   }
 
   val MaxBlockSize = 1000

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -543,7 +543,7 @@ object Utils {
             keys(i) = flatbuffersExtractFieldValue(mapField.keys(i))
             values(i) = flatbuffersExtractFieldValue(mapField.values(i))
           }
-          ArrayBasedMapData(ArrayData.toArrayData(keys), ArrayData.toArrayData(values))
+          ArrayBasedMapData.apply(keys, values)
       }
     }
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -79,6 +79,8 @@ import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeArrayData}
+import org.apache.spark.unsafe.array.ByteArrayMethods
 
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -79,7 +79,6 @@ import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.catalyst.util.ArrayData.toArrayData
 
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
@@ -525,7 +524,7 @@ object Utils {
           for (i <- 0 until arrField.valueLength) {
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
-          toArrayData(arr)
+          arr.toArrayData
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -79,6 +79,8 @@ import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.ArrayData.toArrayData
+
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
@@ -523,7 +525,7 @@ object Utils {
           for (i <- 0 until arrField.valueLength) {
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
-          ArrayData.toArrayData(arr)
+          toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -523,8 +523,12 @@ object Utils {
           val arrField = f.value(new tuix.ArrayField).asInstanceOf[tuix.ArrayField]
           val arr = new Array[Any](arrField.valueLength)
           for (i <- 0 until arrField.valueLength) {
-            println(arrField.value(i))
-            arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
+            arr(i) = 
+              if (!arrField.value(i).isNull()) {
+                flatbuffersExtractFieldValue(arrField.value(i))
+              } else {
+                null
+              }
           }
           ArrayData.toArrayData(arr)
         // case tuix.FieldUnion.MapField =>

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -419,8 +419,7 @@ object Utils {
           tuix.FieldUnion.ArrayField,
           tuix.ArrayField.createArrayField(
             builder, 
-            tuix.ArrayField.createValueVector(builder, fieldsArray.result),
-            x.numElements),
+            tuix.ArrayField.createValueVector(builder, fieldsArray.result)),
           isNull)
       case (null, ArrayType(elementType, containsNull)) =>
         tuix.Field.createField(
@@ -428,8 +427,7 @@ object Utils {
           tuix.FieldUnion.ArrayField,
           tuix.ArrayField.createArrayField(
             builder,
-            tuix.ArrayField.createValueVector(builder, Array.empty),
-            0),
+            tuix.ArrayField.createValueVector(builder, Array.empty)),
           isNull)
       // case (x: Map[_, _], MapType) =>
       //   val keyValuePairs = new ArrayBuffer()

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -81,6 +81,8 @@ import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.catalyst.util.MapData
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData
+
 
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
@@ -535,11 +537,13 @@ object Utils {
           ArrayData.toArrayData(arr)
         case tuix.FieldUnion.MapField =>
           val mapField = f.value(new tuix.MapField).asInstanceOf[tuix.MapField]
-          var map = Map[Any, Any]()
+          val keys = new Array[Any](mapField.keysLength)
+          val values = new Array[Any](mapField.valuesLength)
           for (i <- 0 until mapField.keysLength) {
-            map += ((flatbuffersExtractFieldValue(mapField.keys(i))) -> flatbuffersExtractFieldValue(mapField.values(i)))
+            keys(i) = flatbuffersExtractFieldValue(mapField.keys(i))
+            values(i) = flatbuffersExtractFieldValue(mapField.values(i))
           }
-          map
+          ArrayBasedMapData(ArrayData.toArrayData(keys), ArrayData.toArrayData(values))
       }
     }
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -79,7 +79,11 @@ import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
+
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeArrayData}
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.array.ByteArrayMethods
 
 import org.apache.spark.sql.types._

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -80,12 +80,6 @@ import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, UnsafeArrayData}
-import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.Platform
-import org.apache.spark.unsafe.array.ByteArrayMethods
-
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
@@ -95,45 +89,6 @@ import edu.berkeley.cs.rise.opaque.execution.OpaqueOperatorExec
 import edu.berkeley.cs.rise.opaque.execution.SGXEnclave
 import edu.berkeley.cs.rise.opaque.logical.ConvertToOpaqueOperators
 import edu.berkeley.cs.rise.opaque.logical.EncryptLocalRelation
-
-object ArrayData {
-  def toArrayData(input: Any): ArrayData = input match {
-    case a: Array[Boolean] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Byte] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Short] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Int] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Long] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Float] => UnsafeArrayData.fromPrimitiveArray(a)
-    case a: Array[Double] => UnsafeArrayData.fromPrimitiveArray(a)
-    case other => new GenericArrayData(other)
-  }
-
-
-  /**
-   * Allocate [[UnsafeArrayData]] or [[GenericArrayData]] based on given parameters.
-   *
-   * @param elementSize a size of an element in bytes. If less than zero, the type of an element is
-   *                    non-primitive type
-   * @param numElements the number of elements the array should contain
-   * @param additionalErrorMessage string to include in the error message
-   */
-  def allocateArrayData(
-      elementSize: Int,
-      numElements: Long,
-      additionalErrorMessage: String): ArrayData = {
-    if (elementSize >= 0 && !UnsafeArrayData.shouldUseGenericArrayData(elementSize, numElements)) {
-      UnsafeArrayData.createFreshArray(numElements.toInt, elementSize)
-    } else if (numElements <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toLong) {
-      new GenericArrayData(new Array[Any](numElements.toInt))
-    } else {
-      throw new RuntimeException(s"Cannot create array with $numElements " +
-        "elements of data due to exceeding the limit " +
-        s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH} elements for ArrayData. " +
-        additionalErrorMessage)
-    }
-  }
-}
-
 
 object Utils {
   private val perf: Boolean = System.getenv("SGX_PERF") == "1"
@@ -569,7 +524,7 @@ object Utils {
           for (i <- 0 until arrField.valueLength) {
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
-          toArrayData(arr)
+          ArrayData.toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -433,9 +433,9 @@ object Utils {
       case (x: MapData, MapType(keyType, valueType, valueContainsNull)) =>
         var keys = new ArrayBuilder.ofInt()
         var values = new ArrayBuilder.ofInt()
-        for ((k, v) <- x) {
-          keys += flatbuffersCreateField(builder, k, keyType, isNull)
-          values += flatbuffersCreateField(builder, v, valueType, isNull)
+        for (i <- 0 until x.numElements) {
+          keys += flatbuffersCreateField(builder, x.keyArray.get(i, keyType), keyType, isNull)
+          values += flatbuffersCreateField(builder, x.valueArray.get(i, valueType), valueType, isNull)
         } 
         tuix.Field.createField(
           builder,

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -430,22 +430,20 @@ object Utils {
             tuix.ArrayField.createValueVector(builder, Array.empty)),
           isNull)
       case (x: Map[_, _], MapType(keyType, valueType, valueContainsNull)) =>
-        var keys = new ArrayBuffer()
-        var values = new ArrayBuffer()
+        var keys = new ArrayBuilder.ofInt()
+        var values = new ArrayBuilder.ofInt()
         for (k <- x.keys) {
           val v = x(k)
-          keys += k
-          values += v
+          keys += flatbuffersCreateField(builder, k, keyType, isNull)
+          values += flatbuffersCreateField(builder, v, valueType, isNull)
         } 
-        val keyFields = flatbuffersCreateField(builder, keys.toArray, ArrayType(keyType, false), isNull)
-        val valFields = flatbuffersCreateField(builder, values.toArray, ArrayType(valueType, valueContainsNull), isNull)
         tuix.Field.createField(
           builder,
           tuix.FieldUnion.MapField,
           tuix.MapField.createMapField(
             builder,
-            tuix.MapField.createKeysVector(builder, keyFields),
-            tuix.MapField.createValuesVector(builder, valFields)),
+            tuix.MapField.createKeysVector(builder, keys.result),
+            tuix.MapField.createValuesVector(builder, values.result)),
           isNull)
       case (null, MapType(keyType, valueType, valueContainsNull)) =>
         tuix.Field.createField(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -419,7 +419,8 @@ object Utils {
           tuix.FieldUnion.ArrayField,
           tuix.ArrayField.createArrayField(
             builder, 
-            tuix.ArrayField.createValueVector(builder, fieldsArray.result)),
+            tuix.ArrayField.createValueVector(builder, fieldsArray.result),
+            x.numElements),
           isNull)
       case (null, ArrayType(elementType, containsNull)) =>
         tuix.Field.createField(
@@ -427,7 +428,8 @@ object Utils {
           tuix.FieldUnion.ArrayField,
           tuix.ArrayField.createArrayField(
             builder,
-            tuix.ArrayField.createValueVector(builder, Array.empty)),
+            tuix.ArrayField.createValueVector(builder, Array.empty),
+            0),
           isNull)
       // case (x: Map[_, _], MapType) =>
       //   val keyValuePairs = new ArrayBuffer()

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -524,7 +524,7 @@ object Utils {
           for (i <- 0 until arrField.valueLength) {
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
-          arr.toArrayData
+          ArrayData.toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -530,7 +530,7 @@ object Utils {
                 null
               }
           }
-          ArrayData.toArrayData(arr)
+          // ArrayData.toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -523,6 +523,7 @@ object Utils {
           val arrField = f.value(new tuix.ArrayField).asInstanceOf[tuix.ArrayField]
           val arr = new Array[Any](arrField.valueLength)
           for (i <- 0 until arrField.valueLength) {
+            println(arrField.value(i))
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
           ArrayData.toArrayData(arr)

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -521,15 +521,19 @@ object Utils {
           f.value(new tuix.TimestampField).asInstanceOf[tuix.TimestampField].value
         case tuix.FieldUnion.ArrayField =>
           val arrField = f.value(new tuix.ArrayField).asInstanceOf[tuix.ArrayField]
+          println("524")
           val arr = new Array[Any](arrField.valueLength)
+          println("526")
           for (i <- 0 until arrField.valueLength) {
             arr(i) = 
               if (!arrField.value(i).isNull()) {
+                println("530")
                 flatbuffersExtractFieldValue(arrField.value(i))
               } else {
                 null
               }
           }
+          println("536")
           ArrayData.toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -524,11 +524,22 @@ object Utils {
           for (i <- 0 until arrField.valueLength) {
             arr(i) = flatbuffersExtractFieldValue(arrField.value(i))
           }
-          ArrayData.toArrayData(arr)
+          toArrayData(arr)
         // case tuix.FieldUnion.MapField =>
         //   f.value(new tuix.MapField).asInstanceOf[tuix.MapField].value
       }
     }
+  }
+
+  def toArrayData(input: Any): ArrayData = input match {
+    case a: Array[Boolean] => UnsafeArrayData.fromPrimitiveArray(a)
+    case a: Array[Byte] => UnsafeArrayData.fromPrimitiveArray(a)
+    case a: Array[Short] => UnsafeArrayData.fromPrimitiveArray(a)
+    case a: Array[Int] => UnsafeArrayData.fromPrimitiveArray(a)
+    case a: Array[Long] => UnsafeArrayData.fromPrimitiveArray(a)
+    case a: Array[Float] => UnsafeArrayData.fromPrimitiveArray(a)
+    case a: Array[Double] => UnsafeArrayData.fromPrimitiveArray(a)
+    case other => new GenericArrayData(other)
   }
 
   val MaxBlockSize = 1000

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -80,6 +80,7 @@ import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.MapData
 
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
@@ -429,7 +430,7 @@ object Utils {
             builder,
             tuix.ArrayField.createValueVector(builder, Array.empty)),
           isNull)
-      case (x: Map[_, _], MapType(keyType, valueType, valueContainsNull)) =>
+      case (x: MapData, MapType(keyType, valueType, valueContainsNull)) =>
         var keys = new ArrayBuilder.ofInt()
         var values = new ArrayBuilder.ofInt()
         for (k <- x.keys) {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -108,23 +108,23 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   }
 
   testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
-    val map = Map("x" -> 24, "y" -> 25, "z" -> 26)
-    val data = Seq(
-      (map, "dog"),
-      (map, "cat"),
-      (map, "ant"))
-    val df = makeDF(data, securityLevel, "map", "string")
-    df.show()
-    df.collect
-  }
-
-  testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
     val array: Array[Int] = Array(0, -128, 127, 1)
     val data = Seq(
       (array, "dog"),
       (array, "cat"),
       (array, "ant"))
     val df = makeDF(data, securityLevel, "array", "string")
+    df.show()
+    df.collect
+  }
+
+  testAgainstSpark("create DataFrame with MapType") { securityLevel =>
+    val map = Map("x" -> 24, "y" -> 25, "z" -> 26)
+    val data = Seq(
+      (map, "dog"),
+      (map, "cat"),
+      (map, "ant"))
+    val df = makeDF(data, securityLevel, "map", "string")
     df.show()
     df.collect
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -118,8 +118,6 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     df.collect
   }
 
-  }
-
   testAgainstSpark("filter") { securityLevel =>
     val df = makeDF(
       (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -126,6 +126,7 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
       (map, "ant"))
 
     val df = makeDF(data, securityLevel, "map", "string")
+    df.show()
     df.collect
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -108,6 +108,17 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   }
 
   testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
+    val map = Map("x" -> 24, "y" -> 25, "z" -> 26)
+    val data = Seq(
+      (map, "dog"),
+      (map, "cat"),
+      (map, "ant"))
+    val df = makeDF(data, securityLevel, "map", "string")
+    df.show()
+    df.collect
+  }
+
+  testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
     val array: Array[Int] = Array(0, -128, 127, 1)
     val data = Seq(
       (array, "dog"),

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -124,9 +124,17 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
       (map, "dog"),
       (map, "cat"),
       (map, "ant"))
-    val df = makeDF(data, securityLevel, "map", "string")
+
+    val schema = StructType(Seq(
+      StructField("MapType", MapType(StringType, IntegerType)),
+      StructField("StringType", StringType)))
+
+    val df = spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema)
+
+    securityLevel.applyTo(df).collect
     df.show()
-    df.collect
   }
 
   testAgainstSpark("filter") { securityLevel =>

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -126,7 +126,6 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
       (map, "ant"))
 
     val df = makeDF(data, securityLevel, "map", "string")
-    df.show()
     df.collect
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -107,10 +107,10 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     makeDF(data, securityLevel, "ShortType", "TimestampType").collect
   }
 
-  testAgainstSpark("create DataFrame with ArrayType + MapType") { securityLevel =>
-    val data: Seq[(Array, Map)] = Seq((Array[Int](0 -128, 127), Map("AL" -> "Alabama", "AK" -> "Alaska")))
-    makeDF(data, securityLevel, "ShortType", "TimestampType").collect
-  }
+  // testAgainstSpark("create DataFrame with ArrayType + MapType") { securityLevel =>
+  //   val data: Seq[(Array, Map)] = Seq((Array[Int](0 -128, 127), Map("AL" -> "Alabama", "AK" -> "Alaska")))
+  //   makeDF(data, securityLevel, "ShortType", "TimestampType").collect
+  // }
 
   testAgainstSpark("filter") { securityLevel =>
     val df = makeDF(

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -107,10 +107,18 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     makeDF(data, securityLevel, "ShortType", "TimestampType").collect
   }
 
-  // testAgainstSpark("create DataFrame with ArrayType + MapType") { securityLevel =>
-  //   val data: Seq[(Array, Map)] = Seq((Array[Int](0 -128, 127), Map("AL" -> "Alabama", "AK" -> "Alaska")))
-  //   makeDF(data, securityLevel, "ShortType", "TimestampType").collect
-  // }
+  testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
+    val array: Array[Int] = Array(0, -128, 127, 1)
+    val data = Seq(
+      (array, "dog"),
+      (array, "cat"),
+      (array, "ant"))
+    val df = makeDF(data, securityLevel, "array", "string")
+    df.show()
+    df.collect
+  }
+
+  }
 
   testAgainstSpark("filter") { securityLevel =>
     val df = makeDF(

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -119,22 +119,15 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   }
 
   testAgainstSpark("create DataFrame with MapType") { securityLevel =>
-    val map = Map("x" -> 24, "y" -> 25, "z" -> 26)
+    val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
     val data = Seq(
       (map, "dog"),
       (map, "cat"),
       (map, "ant"))
 
-    val schema = StructType(Seq(
-      StructField("MapType", MapType(StringType, IntegerType)),
-      StructField("StringType", StringType)))
-
-    val df = spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema)
-
-    securityLevel.applyTo(df).collect
+    val df = makeDF(data, securityLevel, "map", "string")
     df.show()
+    df.collect
   }
 
   testAgainstSpark("filter") { securityLevel =>

--- a/type_test.txt
+++ b/type_test.txt
@@ -3,7 +3,7 @@ import org.apache.spark.sql.Row
 import edu.berkeley.cs.rise.opaque.implicits._
 
 
-val binary_array:Array[Byte] = Array(0, 0, 1, 1)
+val binary_array:Array[Int] = Array(0, -128, 127, 1)
 
 val data = Seq(
   Row(binary_array, "dog"),
@@ -13,7 +13,7 @@ val data = Seq(
 
 val schema = StructType(
   List(
-    StructField("binary", BinaryType, true),
+    StructField("array", ArrayType(IntegerType), true),
     StructField("animal_type", StringType, true)
   )
 )


### PR DESCRIPTION
* Add support for serializing and deserializing ArrayType and MapType

* Add tests to ensure this functionality

The following were changes were made by @ankurdave 
* Introduces to_string() overloads for tuix::Field* and all its union
   members (e.g., tuix::IntegerField).

* Uses these to_string() functions for the debugging function
   `void print(const tuix::Field*)`.

* Adds support for casting tuix::ArrayField and tuix::MapField to tuix::StringField. Casts to
   StringField are used for `df.show()`.