### PR TITLE
Use prebuilt SGX SDK binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: required
 jdk: openjdk8
 
 before_install:
+  - jdk_switcher use openjdk8
   - sudo apt-get install wget build-essential libssl-dev
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
   - chmod +x ./sgx_installer.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 jdk: openjdk8
 
 before_install:
-  - sudo apt-get install wget build-essential default-jdk libssl-dev
+  - sudo apt-get install wget build-essential openjdk-8-jdk icedtea-8-plugin libssl-dev
   - sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
   - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 jdk: openjdk8
 
 before_install:
-  - sudo apt-get install wget build-essential openjdk-8-jdk libssl-dev
+  - sudo apt-get install wget build-essential openjdk-8-jdk python cmake libssl-dev
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ scala: 2.11.12
 
 os: linux
 dist: xenial
-sudo: false
 jdk: openjdk8
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: scala
 os: linux
 dist: xenial
 sudo: required
+jdk: openjdk8
 
 before_install:
   - sudo apt-get install wget build-essential libssl-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: scala
 
 os: linux
-dist: trusty
+dist: xenial
 sudo: required
 
 before_install:
   - sudo apt-get install wget build-essential libssl-dev
-  - export CC=gcc-4.8
-  - export CXX=g++-4.8
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
   - chmod +x ./sgx_installer.bin
   - echo yes | ./sgx_installer.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 jdk: openjdk8
 
 before_install:
+  - sudo apt-get install wget build-essential openjdk-8-jdk python cmake libssl-dev
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jdk: openjdk8
 
 before_install:
   - sudo apt-get install wget build-essential openjdk-8-jdk icedtea-8-plugin libssl-dev
+  - env
+  - which javac
   - sudo update-java-alternatives --list
   - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ sudo: required
 jdk: openjdk8
 
 before_install:
-  - jdk_switcher use openjdk8
-  - sudo apt-get install wget build-essential libssl-dev
+  - sudo apt-get install wget build-essential default-jdk libssl-dev
+  - sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
+  - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
   - chmod +x ./sgx_installer.bin
   - echo yes | ./sgx_installer.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk: openjdk8
 before_install:
   - sudo apt-get install wget build-essential openjdk-8-jdk libssl-dev
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin$//')
+  - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
   - chmod +x ./sgx_installer.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: scala
 
 os: linux
 dist: xenial
-sudo: required
+sudo: false
 jdk: openjdk8
 
 before_install:
-  - sudo apt-get install wget build-essential openjdk-8-jdk python cmake libssl-dev
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version
@@ -19,3 +18,14 @@ before_install:
   - export PRIVATE_KEY_PATH=$PWD/private_key.pem
 
 script: sbt -Dspark.ui.showConsoleProgress=false 'set ivyLoggingLevel := UpdateLogging.Quiet' test
+
+# Cache SBT and Ivy artifacts
+# From https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+before_cache:
+  # Clean up the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk: openjdk8
 
 before_install:
   - sudo apt-get install wget build-essential openjdk-8-jdk icedtea-8-plugin libssl-dev
-  - sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
+  - sudo update-java-alternatives --list
   - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
   - chmod +x ./sgx_installer.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+scala: 2.11.12
 
 os: linux
 dist: xenial
@@ -18,7 +19,7 @@ before_install:
   - export SPARKSGX_DATA_DIR=$PWD/data
   - export PRIVATE_KEY_PATH=$PWD/private_key.pem
 
-script: sbt -Dspark.ui.showConsoleProgress=false 'set ivyLoggingLevel := UpdateLogging.Quiet' test
+script: sbt ++$TRAVIS_SCALA_VERSION -Dspark.ui.showConsoleProgress=false 'set ivyLoggingLevel := UpdateLogging.Quiet' test
 
 # Cache SBT and Ivy artifacts
 # From https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,13 @@ dist: trusty
 sudo: required
 
 before_install:
-  - sudo apt-get install build-essential ocaml automake autoconf libtool
+  - sudo apt-get install wget build-essential libssl-dev
   - export CC=gcc-4.8
   - export CXX=g++-4.8
-  - git clone https://github.com/intel/linux-sgx.git -b sgx_2.3
-  - cd linux-sgx
-  - ./download_prebuilt.sh
-  - make --quiet sdk_install_pkg
-  - echo yes | ./linux/installer/bin/sgx_linux_x64_sdk_*.bin
+  - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
+  - chmod +x ./sgx_installer.bin
+  - echo yes | ./sgx_installer.bin
   - source sgxsdk/environment
-  - cd ..
   - openssl ecparam -name prime256v1 -genkey -noout -out private_key.pem
   - export SPARKSGX_DATA_DIR=$PWD/data
   - export PRIVATE_KEY_PATH=$PWD/private_key.pem

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk: openjdk8
 
 before_install:
   - sudo apt-get install wget build-essential openjdk-8-jdk libssl-dev
-  - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin$//')
+  - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ sudo: required
 jdk: openjdk8
 
 before_install:
-  - sudo apt-get install wget build-essential openjdk-8-jdk icedtea-8-plugin libssl-dev
-  - env
-  - which javac
-  - sudo update-java-alternatives --list
+  - sudo apt-get install wget build-essential openjdk-8-jdk libssl-dev
+  - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin$//')
   - java -version
   - wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
   - chmod +x ./sgx_installer.bin

--- a/README.md
+++ b/README.md
@@ -27,21 +27,20 @@ Work-in-progress:
 
 After downloading the Opaque codebase, build and test it as follows:
 
-1. Install dependencies and the Intel SGX SDK with C++11 support:
+1. Install dependencies and the [Intel SGX SDK](https://01.org/intel-software-guard-extensions/downloads):
 
     ```sh
-    # For Ubuntu 16.04:
-    sudo apt-get install build-essential ocaml automake autoconf libtool wget python default-jdk cmake libssl-dev
-    
-    # For Ubuntu 18.04:
-    sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python default-jdk cmake libssl-dev
+    # For Ubuntu 16.04 or 18.04:
+    sudo apt install wget build-essential default-jdk python cmake libssl-dev
 
-    git clone https://github.com/intel/linux-sgx.git -b sgx_2.3
-    cd linux-sgx
-    ./download_prebuilt.sh
-    make sdk_install_pkg
+    # If not on Ubuntu 16.04, choose the correct installer for your platform from https://download.01.org/intel-sgx/linux-2.3.1/
+    wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin
+    chmod +x ./sgx_installer.bin
+
     # Installer will prompt for install path, which can be user-local
-    ./linux/installer/bin/sgx_linux_x64_sdk_*.bin
+    ./sgx_installer.bin
+
+    source sgxsdk/environment
     ```
 
 2. On the master, generate a keypair using OpenSSL for remote attestation. The public key will be automatically hardcoded into the enclave code.
@@ -55,7 +54,6 @@ After downloading the Opaque codebase, build and test it as follows:
 3. Set the following environment variables:
 
     ```sh
-    source sgxsdk/environment # from SGX SDK install directory in step 1
     export SPARKSGX_DATA_DIR=${OPAQUE_HOME}/data
     export PRIVATE_KEY_PATH=${OPAQUE_HOME}/private_key.pem
     ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After downloading the Opaque codebase, build and test it as follows:
 
     ```sh
     # For Ubuntu 16.04 or 18.04:
-    sudo apt install wget build-essential default-jdk python cmake libssl-dev
+    sudo apt install wget build-essential openjdk-8-jdk python cmake libssl-dev
 
     # If not on Ubuntu 16.04, choose the correct installer for your platform from https://download.01.org/intel-sgx/linux-2.3.1/
     wget -O sgx_installer.bin https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin

--- a/data/tpch/synth-tpch-data
+++ b/data/tpch/synth-tpch-data
@@ -10,4 +10,5 @@ cd tpch-dbgen
 make
 ./dbgen -vf -s 0.01
 mkdir -p $SPARKSGX_DATA_DIR/tpch/sf_small
+ls -la # For debugging "permission denied" errors on the next line
 cp *.tbl $SPARKSGX_DATA_DIR/tpch/sf_small/

--- a/data/tpch/synth-tpch-data
+++ b/data/tpch/synth-tpch-data
@@ -10,5 +10,5 @@ cd tpch-dbgen
 make
 ./dbgen -vf -s 0.01
 mkdir -p $SPARKSGX_DATA_DIR/tpch/sf_small
-ls -la # For debugging "permission denied" errors on the next line
+chmod u+r *.tbl
 cp *.tbl $SPARKSGX_DATA_DIR/tpch/sf_small/


### PR DESCRIPTION
Using Intel's prebuilt binaries requires Travis CI builds to use 16.04 (just released yesterday [1]) instead of 14.04.

In an effort to further speed up Travis builds, this PR also caches SBT and Ivy artifacts across builds.

[1] https://blog.travis-ci.com/2018-11-08-xenial-release