### PR TITLE
Remove driver-side enclave dependency

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
@@ -76,7 +76,7 @@ case class EncryptedLocalTableScanExec(
     // Encrypt each local partition
     val encryptedPartitions: Seq[Block] =
       slicedPlaintextData.map(slice =>
-        Utils.encryptInternalRowsFlatbuffers(slice, output.map(_.dataType)))
+        Utils.encryptInternalRowsFlatbuffers(slice, output.map(_.dataType), useEnclave = false))
 
     // Make an RDD from the encrypted partitions
     sqlContext.sparkContext.parallelize(encryptedPartitions)
@@ -90,7 +90,8 @@ case class EncryptExec(child: SparkPlan)
 
   override def executeBlocked(): RDD[Block] = {
     child.execute().mapPartitions { rowIter =>
-      Iterator(Utils.encryptInternalRowsFlatbuffers(rowIter.toSeq, output.map(_.dataType)))
+      Iterator(Utils.encryptInternalRowsFlatbuffers(
+        rowIter.toSeq, output.map(_.dataType), useEnclave = true))
     }
   }
 }


### PR DESCRIPTION
- Encryption (Utils.encryptInternalRowsFlatbuffers) now uses Java crypto on the
  driver and an enclave on the workers, controlled by a flag.

- Decryption is only called from the driver, so always uses Java crypto.

- For sorting, the `FindRangeBounds` preprocessing task is shipped to a single
  worker, where it uses the existing enclave implementation. (Thanks to András
  Méhes.)

Fixes #64.