### PR TITLE
Clean up and refactor readers and writers

### DIFF
--- a/src/enclave/Enclave/CMakeLists.txt
+++ b/src/enclave/Enclave/CMakeLists.txt
@@ -8,6 +8,8 @@ set(SOURCES
   Enclave.cpp
   Filter.cpp
   Flatbuffers.cpp
+  FlatbuffersReaders.cpp
+  FlatbuffersWriters.cpp
   Join.cpp
   Project.cpp
   Sort.cpp

--- a/src/enclave/Enclave/Flatbuffers.h
+++ b/src/enclave/Enclave/Flatbuffers.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <time.h>
+#include <typeinfo>
 
 #include "EncryptedBlock_generated.h"
 #include "Expr_generated.h"
@@ -17,6 +18,62 @@
 #define FLATBUFFERS_H
 
 using namespace edu::berkeley::cs::rise::opaque;
+
+/**
+ * A read-only, typed Flatbuffers buffer, along with its length. Does not own its buffer.
+ */
+template<typename T> struct BufferRefView {
+  BufferRefView() : buf(nullptr), len(0) {}
+  BufferRefView(uint8_t *_buf, flatbuffers::uoffset_t _len)
+    : buf(_buf), len(_len) {}
+
+  const T *root() const { return flatbuffers::GetRoot<T>(buf); }
+
+  void verify() {
+    flatbuffers::Verifier verifier(buf, len);
+    if (!verifier.VerifyBuffer<T>(nullptr)) {
+      throw std::runtime_error(
+        std::string("Corrupt ")
+        + std::string(typeid(T).name())
+        + std::string(" buffer of length ")
+        + std::to_string(len));
+    }
+  }
+
+  const uint8_t *buf;
+  flatbuffers::uoffset_t len;
+};
+
+/**
+ * A typed Flatbuffers buffer stored in untrusted memory, along with its length. Owns its buffer.
+ */
+template<typename T> struct UntrustedBufferRef {
+  UntrustedBufferRef() : buf(nullptr), len(0) {}
+  UntrustedBufferRef(
+    std::unique_ptr<uint8_t, decltype(&ocall_free)> _buf,
+    flatbuffers::uoffset_t _len)
+    : buf(std::move(_buf)), len(_len) {}
+
+  const T *root() const { return flatbuffers::GetRoot<T>(buf); }
+
+  void verify() {
+    flatbuffers::Verifier verifier(buf, len);
+    if (!verifier.VerifyBuffer<T>(nullptr)) {
+      throw std::runtime_error(
+        std::string("Corrupt ")
+        + std::string(typeid(T).name())
+        + std::string(" buffer of length ")
+        + std::to_string(len));
+    }
+  }
+
+  BufferRefView<T> view() const {
+    return BufferRefView<T>(buf.get(), len);
+  }
+
+  std::unique_ptr<uint8_t, decltype(&ocall_free)> buf;
+  flatbuffers::uoffset_t len;
+};
 
 /** Wrapper around a date that provides conversions to various types. */
 class Date {
@@ -126,338 +183,9 @@ template<typename T> flatbuffers::Offset<T> GetOffset(
                                 - reinterpret_cast<const uint8_t *>(pointer));
 }
 
-class EncryptedBlocksToEncryptedBlockReader {
-public:
-  EncryptedBlocksToEncryptedBlockReader(uint8_t *buf, size_t len) {
-    flatbuffers::Verifier v(buf, len);
-    if (!v.VerifyBuffer<tuix::EncryptedBlocks>(nullptr)) {
-      throw std::runtime_error(
-        std::string("Corrupt EncryptedBlocks buffer of length ")
-        + std::to_string(len));
-    }
-    encrypted_blocks = flatbuffers::GetRoot<tuix::EncryptedBlocks>(buf);
-    debug("EncryptedBlocksToEncryptedBlockReader: %d blocks\n", encrypted_blocks->blocks()->size());
-  }
-  flatbuffers::Vector<flatbuffers::Offset<tuix::EncryptedBlock>>::const_iterator begin() {
-    return encrypted_blocks->blocks()->begin();
-  }
-  flatbuffers::Vector<flatbuffers::Offset<tuix::EncryptedBlock>>::const_iterator end() {
-    return encrypted_blocks->blocks()->end();
-  }
-
-private:
-  const tuix::EncryptedBlocks *encrypted_blocks;
-};
-
-class EncryptedBlockToRowReader {
-public:
-  EncryptedBlockToRowReader() : rows(nullptr), initialized(false) {}
-
-  void reset(uint8_t *buf, size_t len) {
-    flatbuffers::Verifier v(buf, len);
-    if (!v.VerifyBuffer<tuix::EncryptedBlock>(nullptr)) {
-      throw std::runtime_error(
-        std::string("Corrupt EncryptedBlock buffer of length ")
-        + std::to_string(len));
-    }
-    auto encrypted_block = flatbuffers::GetRoot<tuix::EncryptedBlock>(buf);
-    init(encrypted_block);
-  }
-
-  void reset(const tuix::EncryptedBlock *encrypted_block) {
-    init(encrypted_block);
-  }
-
-  bool has_next() {
-    return initialized && row_idx < rows->rows()->size();
-  }
-
-  const tuix::Row *next() {
-    return rows->rows()->Get(row_idx++);
-  }
-
-  flatbuffers::Vector<flatbuffers::Offset<tuix::Row>>::const_iterator begin() {
-    return rows->rows()->begin();
-  }
-
-  flatbuffers::Vector<flatbuffers::Offset<tuix::Row>>::const_iterator end() {
-    return rows->rows()->end();
-  }
-
-private:
-  void init(const tuix::EncryptedBlock *encrypted_block) {
-    uint32_t num_rows = encrypted_block->num_rows();
-
-    const size_t rows_len = dec_size(encrypted_block->enc_rows()->size());
-    rows_buf.reset(new uint8_t[rows_len]);
-    decrypt(encrypted_block->enc_rows()->data(), encrypted_block->enc_rows()->size(),
-            rows_buf.get());
-    flatbuffers::Verifier v(rows_buf.get(), rows_len);
-    if (!v.VerifyBuffer<tuix::Rows>(nullptr)) {
-      throw std::runtime_error(
-        std::string("Corrupt Rows buffer of length ")
-        + std::to_string(rows_len));
-    }
-
-    rows = flatbuffers::GetRoot<tuix::Rows>(rows_buf.get());
-    if (rows->rows()->size() != num_rows) {
-      throw std::runtime_error(
-        std::string("EncryptedBlock claimed to contain ")
-        + std::to_string(num_rows)
-        + std::string("rows but actually contains ")
-        + std::to_string(rows->rows()->size())
-        + std::string(" rows"));
-    }
-
-    row_idx = 0;
-    initialized = true;
-  }
-
-  std::unique_ptr<uint8_t> rows_buf;
-  const tuix::Rows *rows;
-  uint32_t row_idx;
-  bool initialized;
-};
-
-class EncryptedBlocksToRowReader {
-  typedef flatbuffers::Vector<
-    flatbuffers::Offset<tuix::EncryptedBlock>>::const_iterator EncryptedBlockIterator;
-  typedef flatbuffers::Vector<flatbuffers::Offset<tuix::Row>>::const_iterator RowIterator;
-
-public:
-  EncryptedBlocksToRowReader(uint8_t *buf, size_t len)
-    : block_idx(0) {
-    flatbuffers::Verifier v(buf, len);
-    if (!v.VerifyBuffer<tuix::EncryptedBlocks>(nullptr)) {
-      throw std::runtime_error(
-        std::string("Corrupt EncryptedBlocks buffer of length ")
-        + std::to_string(len));
-    }
-    encrypted_blocks = flatbuffers::GetRoot<tuix::EncryptedBlocks>(buf);
-    init_row_reader();
-  }
-
-  EncryptedBlocksToRowReader(const tuix::EncryptedBlocks *encrypted_blocks)
-    : encrypted_blocks(encrypted_blocks), block_idx(0) {
-    init_row_reader();
-  }
-
-  uint32_t num_rows() {
-    uint32_t result = 0;
-    for (auto it = encrypted_blocks->blocks()->begin();
-         it != encrypted_blocks->blocks()->end(); ++it) {
-      result += it->num_rows();
-    }
-    return result;
-  }
-
-  bool has_next() {
-    return r.has_next() || block_idx + 1 < encrypted_blocks->blocks()->size();
-  }
-
-  const tuix::Row *next() {
-    // Note: this will invalidate any pointers returned by previous invocations of this method
-    if (!r.has_next()) {
-      assert(block_idx + 1 < encrypted_blocks->blocks()->size());
-      block_idx++;
-      init_row_reader();
-    }
-
-    return r.next();
-  }
-
-private:
-  void init_row_reader() {
-    if (block_idx < encrypted_blocks->blocks()->size()) {
-      r.reset(encrypted_blocks->blocks()->Get(block_idx));
-    }
-  }
-
-  const tuix::EncryptedBlocks *encrypted_blocks;
-  uint32_t block_idx;
-  EncryptedBlockToRowReader r;
-};
-
-class SortedRunsReader {
-public:
-  SortedRunsReader(uint8_t *buf, size_t len)
-    : buf(nullptr) {
-    reset(buf, len);
-  }
-
-  void reset(uint8_t *buf, size_t len) {
-    this->buf = buf;
-
-    flatbuffers::Verifier v(buf, len);
-    if (!v.VerifyBuffer<tuix::SortedRuns>(nullptr)) {
-      throw std::runtime_error(
-        std::string("Corrupt SortedRuns buffer of length ")
-        + std::to_string(len));
-    }
-    sorted_runs = flatbuffers::GetRoot<tuix::SortedRuns>(buf);
-
-    run_readers.clear();
-    for (auto it = sorted_runs->runs()->begin(); it != sorted_runs->runs()->end(); ++it) {
-      run_readers.push_back(EncryptedBlocksToRowReader(*it));
-    }
-  }
-
-  uint32_t num_runs() {
-    return sorted_runs->runs()->size();
-  }
-
-  bool run_has_next(uint32_t run_idx) {
-    return run_readers[run_idx].has_next();
-  }
-
-  const tuix::Row *next_from_run(uint32_t run_idx) {
-    return run_readers[run_idx].next();
-  }
-
-private:
-  uint8_t *buf;
-  const tuix::SortedRuns *sorted_runs;
-  std::vector<EncryptedBlocksToRowReader> run_readers;
-};
-
-
-class UntrustedMemoryAllocator : public flatbuffers::Allocator {
-public:
-  virtual uint8_t *allocate(size_t size) {
-    uint8_t *result = nullptr;
-    ocall_malloc(size, &result);
-    return result;
-  }
-  virtual void deallocate(uint8_t *p, size_t size) {
-    (void)size;
-    ocall_free(p);
-  }
-};
-
-class FlatbuffersRowWriter {
-public:
-  FlatbuffersRowWriter()
-    : builder(), rows_vector(), total_num_rows(0), untrusted_alloc(),
-      enc_block_builder(1024, &untrusted_alloc) {}
-
-  void clear() {
-    builder.Clear();
-    rows_vector.clear();
-    total_num_rows = 0;
-    enc_block_builder.Clear();
-    enc_block_vector.clear();
-  }
-
-  /** Copy the given Row to the output. */
-  void write(const tuix::Row *row) {
-    rows_vector.push_back(flatbuffers_copy(row, builder));
-    total_num_rows++;
-    maybe_finish_block();
-  }
-
-  /** Copy the given Fields to the output. */
-  void write(const std::vector<const tuix::Field *> &row_fields) {
-    flatbuffers::uoffset_t num_fields = row_fields.size();
-    std::vector<flatbuffers::Offset<tuix::Field>> field_values(num_fields);
-    for (flatbuffers::uoffset_t i = 0; i < num_fields; i++) {
-      field_values[i] = flatbuffers_copy<tuix::Field>(row_fields[i], builder);
-    }
-    rows_vector.push_back(tuix::CreateRowDirect(builder, &field_values));
-    total_num_rows++;
-    maybe_finish_block();
-  }
-
-  /**
-   * Concatenate the fields of the two given Rows and write the resulting single Row to the output.
-   */
-  void write(const tuix::Row *row1, const tuix::Row *row2) {
-    flatbuffers::uoffset_t num_fields = row1->field_values()->size() + row2->field_values()->size();
-    std::vector<flatbuffers::Offset<tuix::Field>> field_values(num_fields);
-    flatbuffers::uoffset_t i = 0;
-    for (auto it = row1->field_values()->begin(); it != row1->field_values()->end(); ++it, ++i) {
-      field_values[i] = flatbuffers_copy<tuix::Field>(*it, builder);
-    }
-    for (auto it = row2->field_values()->begin(); it != row2->field_values()->end(); ++it, ++i) {
-      field_values[i] = flatbuffers_copy<tuix::Field>(*it, builder);
-    }
-    rows_vector.push_back(tuix::CreateRowDirect(builder, &field_values));
-    total_num_rows++;
-    maybe_finish_block();
-  }
-
-  void write_encrypted_block() {
-    builder.Finish(tuix::CreateRowsDirect(builder, &rows_vector));
-    size_t enc_rows_len = enc_size(builder.GetSize());
-
-    uint8_t *enc_rows_ptr = nullptr;
-    ocall_malloc(enc_rows_len, &enc_rows_ptr);
-
-    std::unique_ptr<uint8_t, decltype(&ocall_free)> enc_rows(enc_rows_ptr, &ocall_free);
-    encrypt(builder.GetBufferPointer(), builder.GetSize(), enc_rows.get());
-
-    enc_block_vector.push_back(
-      tuix::CreateEncryptedBlock(
-        enc_block_builder,
-        rows_vector.size(),
-        enc_block_builder.CreateVector(enc_rows.get(), enc_rows_len)));
-
-    builder.Clear();
-    rows_vector.clear();
-  }
-
-  flatbuffers::Offset<tuix::EncryptedBlocks> write_encrypted_blocks() {
-    if (rows_vector.size() > 0) {
-      write_encrypted_block();
-    }
-    auto result = tuix::CreateEncryptedBlocksDirect(enc_block_builder, &enc_block_vector);
-    enc_block_vector.clear();
-    return result;
-  }
-
-  flatbuffers::Offset<tuix::SortedRuns> write_sorted_runs(
-    std::vector<flatbuffers::Offset<tuix::EncryptedBlocks>> &enc_blocks_vector) {
-    return tuix::CreateSortedRunsDirect(enc_block_builder, &enc_blocks_vector);
-  }
-
-  template<typename T>
-  void finish(flatbuffers::Offset<T> root) {
-    enc_block_builder.Finish<T>(root);
-  }
-
-  std::unique_ptr<uint8_t, decltype(&ocall_free)> output_buffer() {
-    uint8_t *buf_ptr;
-    ocall_malloc(output_size(), &buf_ptr);
-
-    std::unique_ptr<uint8_t, decltype(&ocall_free)> buf(buf_ptr, &ocall_free);
-    memcpy(buf.get(), enc_block_builder.GetBufferPointer(), output_size());
-    return buf;
-  }
-
-  size_t output_size() {
-    return enc_block_builder.GetSize();
-  }
-
-  uint32_t output_num_rows() {
-    return total_num_rows;
-  }
-
-private:
-  void maybe_finish_block() {
-    if (builder.GetSize() >= MAX_BLOCK_SIZE) {
-      write_encrypted_block();
-    }
-  }
-
-  flatbuffers::FlatBufferBuilder builder;
-  std::vector<flatbuffers::Offset<tuix::Row>> rows_vector;
-  uint32_t total_num_rows;
-
-  // For writing the resulting EncryptedBlocks
-  UntrustedMemoryAllocator untrusted_alloc;
-  flatbuffers::FlatBufferBuilder enc_block_builder;
-  std::vector<flatbuffers::Offset<tuix::EncryptedBlock>> enc_block_vector;
-};
-
+/**
+ * Container for a single row which can be accessed and reassigned.
+ */
 class FlatbuffersTemporaryRow {
 public:
   FlatbuffersTemporaryRow() : builder(), row(nullptr) {}

--- a/src/enclave/Enclave/FlatbuffersReaders.cpp
+++ b/src/enclave/Enclave/FlatbuffersReaders.cpp
@@ -1,0 +1,99 @@
+#include "FlatbuffersReaders.h"
+
+void EncryptedBlockToRowReader::reset(const tuix::EncryptedBlock *encrypted_block) {
+  uint32_t num_rows = encrypted_block->num_rows();
+
+  const size_t rows_len = dec_size(encrypted_block->enc_rows()->size());
+  rows_buf.reset(new uint8_t[rows_len]);
+  decrypt(encrypted_block->enc_rows()->data(), encrypted_block->enc_rows()->size(),
+          rows_buf.get());
+  BufferRefView<tuix::Rows> buf(rows_buf.get(), rows_len);
+  buf.verify();
+
+  rows = buf.root();
+  if (rows->rows()->size() != num_rows) {
+    throw std::runtime_error(
+      std::string("EncryptedBlock claimed to contain ")
+      + std::to_string(num_rows)
+      + std::string("rows but actually contains ")
+      + std::to_string(rows->rows()->size())
+      + std::string(" rows"));
+  }
+
+  row_idx = 0;
+  initialized = true;
+}
+
+RowReader::RowReader(BufferRefView<tuix::EncryptedBlocks> buf) {
+  reset(buf);
+}
+
+RowReader::RowReader(const tuix::EncryptedBlocks *encrypted_blocks) {
+  reset(encrypted_blocks);
+}
+
+void RowReader::reset(BufferRefView<tuix::EncryptedBlocks> buf) {
+  buf.verify();
+  reset(buf.root());
+}
+
+void RowReader::reset(const tuix::EncryptedBlocks *encrypted_blocks) {
+  this->encrypted_blocks = encrypted_blocks;
+  block_idx = 0;
+  init_block_reader();
+}
+
+uint32_t RowReader::num_rows() {
+  uint32_t result = 0;
+  for (auto it = encrypted_blocks->blocks()->begin();
+       it != encrypted_blocks->blocks()->end(); ++it) {
+    result += it->num_rows();
+  }
+  return result;
+}
+
+bool RowReader::has_next() {
+  return block_reader.has_next() || block_idx + 1 < encrypted_blocks->blocks()->size();
+}
+
+const tuix::Row *RowReader::next() {
+  // Note: this will invalidate any pointers returned by previous invocations of this method
+  if (!block_reader.has_next()) {
+    assert(block_idx + 1 < encrypted_blocks->blocks()->size());
+    block_idx++;
+    init_block_reader();
+  }
+
+  return block_reader.next();
+}
+
+void RowReader::init_block_reader() {
+  if (block_idx < encrypted_blocks->blocks()->size()) {
+    block_reader.reset(encrypted_blocks->blocks()->Get(block_idx));
+  }
+}
+
+SortedRunsReader::SortedRunsReader(BufferRefView<tuix::SortedRuns> buf) {
+  reset(buf);
+}
+
+void SortedRunsReader::reset(BufferRefView<tuix::SortedRuns> buf) {
+  buf.verify();
+  sorted_runs = buf.root();
+  run_readers.clear();
+  for (auto it = sorted_runs->runs()->begin(); it != sorted_runs->runs()->end(); ++it) {
+    run_readers.push_back(RowReader(*it));
+  }
+}
+
+uint32_t SortedRunsReader::num_runs() {
+  return sorted_runs->runs()->size();
+}
+
+bool SortedRunsReader::run_has_next(uint32_t run_idx) {
+  return run_readers[run_idx].has_next();
+}
+
+const tuix::Row *SortedRunsReader::next_from_run(uint32_t run_idx) {
+  return run_readers[run_idx].next();
+}

--- a/src/enclave/Enclave/FlatbuffersReaders.h
+++ b/src/enclave/Enclave/FlatbuffersReaders.h
@@ -1,0 +1,106 @@
+#include "Flatbuffers.h"
+
+#ifndef FLATBUFFERS_READERS_H
+#define FLATBUFFERS_READERS_H
+
+using namespace edu::berkeley::cs::rise::opaque;
+
+/**
+ * A reader for Row objects within an EncryptedBlock object that provides both iterator-based and
+ * range-style interfaces.
+ */
+class EncryptedBlockToRowReader {
+public:
+  EncryptedBlockToRowReader() : rows(nullptr), initialized(false) {}
+
+  void reset(const tuix::EncryptedBlock *encrypted_block);
+
+  bool has_next() {
+    return initialized && row_idx < rows->rows()->size();
+  }
+
+  const tuix::Row *next() {
+    return rows->rows()->Get(row_idx++);
+  }
+
+  flatbuffers::Vector<flatbuffers::Offset<tuix::Row>>::const_iterator begin() {
+    return rows->rows()->begin();
+  }
+
+  flatbuffers::Vector<flatbuffers::Offset<tuix::Row>>::const_iterator end() {
+    return rows->rows()->end();
+  }
+
+private:
+  std::unique_ptr<uint8_t> rows_buf;
+  const tuix::Rows *rows;
+  uint32_t row_idx;
+  bool initialized;
+};
+
+/** An iterator-style reader for Rows organized into EncryptedBlocks. */
+class RowReader {
+public:
+  RowReader(BufferRefView<tuix::EncryptedBlocks> buf);
+  RowReader(const tuix::EncryptedBlocks *encrypted_blocks);
+
+  void reset(BufferRefView<tuix::EncryptedBlocks> buf);
+  void reset(const tuix::EncryptedBlocks *encrypted_blocks);
+
+  uint32_t num_rows();
+  bool has_next();
+  /** Access the next Row. Invalidates any previously-returned Row pointers. */
+  const tuix::Row *next();
+
+private:
+  void init_block_reader();
+
+  const tuix::EncryptedBlocks *encrypted_blocks;
+  uint32_t block_idx;
+  EncryptedBlockToRowReader block_reader;
+};
+
+/**
+ * A reader for Rows organized into sorted runs.
+ *
+ * Different runs can be read independently. Within a run, access is performed using an
+ * iterator-style sequential interface.
+ */
+class SortedRunsReader {
+public:
+  SortedRunsReader(BufferRefView<tuix::SortedRuns> buf);
+
+  void reset(BufferRefView<tuix::SortedRuns> buf);
+
+  uint32_t num_runs();
+  bool run_has_next(uint32_t run_idx);
+  /**
+   * Access the next Row from the given run. Invalidates any previously-returned Row pointers from
+   * the same run.
+   */
+  const tuix::Row *next_from_run(uint32_t run_idx);
+
+private:
+  const tuix::SortedRuns *sorted_runs;
+  std::vector<RowReader> run_readers;
+};
+
+/** A range-style reader for EncryptedBlock objects within an EncryptedBlocks object. */
+class EncryptedBlocksToEncryptedBlockReader {
+public:
+  EncryptedBlocksToEncryptedBlockReader(BufferRefView<tuix::EncryptedBlocks> buf) {
+    buf.verify();
+    encrypted_blocks = buf.root();
+  }
+  flatbuffers::Vector<flatbuffers::Offset<tuix::EncryptedBlock>>::const_iterator begin() {
+    return encrypted_blocks->blocks()->begin();
+  }
+  flatbuffers::Vector<flatbuffers::Offset<tuix::EncryptedBlock>>::const_iterator end() {
+    return encrypted_blocks->blocks()->end();
+  }
+
+private:
+  const tuix::EncryptedBlocks *encrypted_blocks;
+};
+
+#endif

--- a/src/enclave/Enclave/FlatbuffersWriters.cpp
+++ b/src/enclave/Enclave/FlatbuffersWriters.cpp
@@ -1,0 +1,159 @@
+#include "FlatbuffersWriters.h"
+
+void RowWriter::clear() {
+  builder.Clear();
+  rows_vector.clear();
+  total_num_rows = 0;
+  enc_block_builder.Clear();
+  enc_block_vector.clear();
+  finished = false;
+}
+
+void RowWriter::append(const tuix::Row *row) {
+  rows_vector.push_back(flatbuffers_copy(row, builder));
+  total_num_rows++;
+  maybe_finish_block();
+}
+
+void RowWriter::append(const std::vector<const tuix::Field *> &row_fields) {
+  flatbuffers::uoffset_t num_fields = row_fields.size();
+  std::vector<flatbuffers::Offset<tuix::Field>> field_values(num_fields);
+  for (flatbuffers::uoffset_t i = 0; i < num_fields; i++) {
+    field_values[i] = flatbuffers_copy<tuix::Field>(row_fields[i], builder);
+  }
+  rows_vector.push_back(tuix::CreateRowDirect(builder, &field_values));
+  total_num_rows++;
+  maybe_finish_block();
+}
+
+void RowWriter::append(const tuix::Row *row1, const tuix::Row *row2) {
+  flatbuffers::uoffset_t num_fields = row1->field_values()->size() + row2->field_values()->size();
+  std::vector<flatbuffers::Offset<tuix::Field>> field_values(num_fields);
+  flatbuffers::uoffset_t i = 0;
+  for (auto it = row1->field_values()->begin(); it != row1->field_values()->end(); ++it, ++i) {
+    field_values[i] = flatbuffers_copy<tuix::Field>(*it, builder);
+  }
+  for (auto it = row2->field_values()->begin(); it != row2->field_values()->end(); ++it, ++i) {
+    field_values[i] = flatbuffers_copy<tuix::Field>(*it, builder);
+  }
+  rows_vector.push_back(tuix::CreateRowDirect(builder, &field_values));
+  total_num_rows++;
+  maybe_finish_block();
+}
+
+UntrustedBufferRef<tuix::EncryptedBlocks> RowWriter::output_buffer() {
+  if (!finished) {
+    finish_blocks();
+  }
+
+  uint8_t *buf_ptr;
+  ocall_malloc(enc_block_builder.GetSize(), &buf_ptr);
+
+  std::unique_ptr<uint8_t, decltype(&ocall_free)> buf(buf_ptr, &ocall_free);
+  memcpy(buf.get(), enc_block_builder.GetBufferPointer(), enc_block_builder.GetSize());
+
+  UntrustedBufferRef<tuix::EncryptedBlocks> buffer(
+    std::move(buf), enc_block_builder.GetSize());
+  return buffer;
+}
+
+void RowWriter::output_buffer(uint8_t **output_rows, size_t *output_rows_length) {
+  auto result = output_buffer();
+  *output_rows = result.buf.release();
+  *output_rows_length = result.len;
+}
+
+uint32_t RowWriter::num_rows() {
+  return total_num_rows;
+}
+
+
+void RowWriter::maybe_finish_block() {
+  if (builder.GetSize() >= MAX_BLOCK_SIZE) {
+    finish_block();
+  }
+}
+
+void RowWriter::finish_block() {
+  builder.Finish(tuix::CreateRowsDirect(builder, &rows_vector));
+  size_t enc_rows_len = enc_size(builder.GetSize());
+
+  uint8_t *enc_rows_ptr = nullptr;
+  ocall_malloc(enc_rows_len, &enc_rows_ptr);
+
+  std::unique_ptr<uint8_t, decltype(&ocall_free)> enc_rows(enc_rows_ptr, &ocall_free);
+  encrypt(builder.GetBufferPointer(), builder.GetSize(), enc_rows.get());
+
+  enc_block_vector.push_back(
+    tuix::CreateEncryptedBlock(
+      enc_block_builder,
+      rows_vector.size(),
+      enc_block_builder.CreateVector(enc_rows.get(), enc_rows_len)));
+
+  builder.Clear();
+  rows_vector.clear();
+}
+
+flatbuffers::Offset<tuix::EncryptedBlocks> RowWriter::finish_blocks() {
+  if (rows_vector.size() > 0) {
+    finish_block();
+  }
+  auto result = tuix::CreateEncryptedBlocksDirect(enc_block_builder, &enc_block_vector);
+  enc_block_builder.Finish(result);
+  enc_block_vector.clear();
+
+  finished = true;
+
+  return result;
+}
+
+void SortedRunsWriter::clear() {
+  container.clear();
+  runs.clear();
+}
+
+void SortedRunsWriter::append(const tuix::Row *row) {
+  container.append(row);
+}
+
+void SortedRunsWriter::append(const std::vector<const tuix::Field *> &row_fields) {
+  container.append(row_fields);
+}
+
+void SortedRunsWriter::append(const tuix::Row *row1, const tuix::Row *row2) {
+  container.append(row1, row2);
+}
+
+void SortedRunsWriter::finish_run() {
+  runs.push_back(container.finish_blocks());
+}
+
+uint32_t SortedRunsWriter::num_runs() {
+  return runs.size();
+}
+
+UntrustedBufferRef<tuix::SortedRuns> SortedRunsWriter::output_buffer() {
+  container.enc_block_builder.Finish(
+    tuix::CreateSortedRunsDirect(container.enc_block_builder, &runs));
+
+  uint8_t *buf_ptr;
+  ocall_malloc(container.enc_block_builder.GetSize(), &buf_ptr);
+
+  std::unique_ptr<uint8_t, decltype(&ocall_free)> buf(buf_ptr, &ocall_free);
+  memcpy(buf.get(),
+         container.enc_block_builder.GetBufferPointer(),
+         container.enc_block_builder.GetSize());
+
+  UntrustedBufferRef<tuix::SortedRuns> buffer(
+    std::move(buf), container.enc_block_builder.GetSize());
+  return buffer;
+}
+
+RowWriter *SortedRunsWriter::as_row_writer() {
+  if (runs.size() > 1) {
+    throw std::runtime_error("Invalid attempt to convert SortedRunsWriter with more than one run "
+                             "to RowWriter");
+  }
+
+  return &container;
+}

--- a/src/enclave/Enclave/FlatbuffersWriters.h
+++ b/src/enclave/Enclave/FlatbuffersWriters.h
@@ -1,0 +1,105 @@
+#include "Flatbuffers.h"
+
+#ifndef FLATBUFFERS_WRITERS_H
+#define FLATBUFFERS_WRITERS_H
+
+using namespace edu::berkeley::cs::rise::opaque;
+
+class UntrustedMemoryAllocator : public flatbuffers::Allocator {
+public:
+  virtual uint8_t *allocate(size_t size) {
+    uint8_t *result = nullptr;
+    ocall_malloc(size, &result);
+    return result;
+  }
+  virtual void deallocate(uint8_t *p, size_t size) {
+    (void)size;
+    ocall_free(p);
+  }
+};
+
+/** Append-only container for rows wrapped in tuix::EncryptedBlocks. */
+class RowWriter {
+public:
+  RowWriter()
+    : builder(), rows_vector(), total_num_rows(0), untrusted_alloc(),
+      enc_block_builder(1024, &untrusted_alloc), finished(false) {}
+
+  void clear();
+
+  /** Append the given Row. */
+  void append(const tuix::Row *row);
+
+  /** Append the given `Field`s as a Row. */
+  void append(const std::vector<const tuix::Field *> &row_fields);
+
+  /** Concatenate the fields of the two given `Row`s and append the resulting single Row. */
+  void append(const tuix::Row *row1, const tuix::Row *row2);
+
+  /** Expose the stored rows as a buffer. */
+  UntrustedBufferRef<tuix::EncryptedBlocks> output_buffer();
+
+  /** Expose the stored rows as a buffer. The caller takes ownership of the resulting buffer. */
+  void output_buffer(uint8_t **output_rows, size_t *output_rows_length);
+
+  /** Count how many rows have been appended. */
+  uint32_t num_rows();
+
+private:
+  void maybe_finish_block();
+  void finish_block();
+  flatbuffers::Offset<tuix::EncryptedBlocks> finish_blocks();
+
+  flatbuffers::FlatBufferBuilder builder;
+  std::vector<flatbuffers::Offset<tuix::Row>> rows_vector;
+  uint32_t total_num_rows;
+
+  // For writing the resulting EncryptedBlocks
+  UntrustedMemoryAllocator untrusted_alloc;
+  flatbuffers::FlatBufferBuilder enc_block_builder;
+  std::vector<flatbuffers::Offset<tuix::EncryptedBlock>> enc_block_vector;
+
+  bool finished;
+
+  friend class SortedRunsWriter;
+};
+
+/** Append-only container for rows wrapped in tuix::SortedRuns. */
+class SortedRunsWriter {
+public:
+  SortedRunsWriter() : container() {}
+
+  void clear();
+
+  /** Append the given Row. */
+  void append(const tuix::Row *row);
+
+  /** Append the given `Field`s as a Row. */
+  void append(const std::vector<const tuix::Field *> &row_fields);
+
+  /** Concatenate the fields of the two given `Row`s and append the resulting single Row. */
+  void append(const tuix::Row *row1, const tuix::Row *row2);
+
+  /**
+   * Wrap all rows written since the last call to this method into a single sorted run.
+   */
+  void finish_run();
+
+  /** Count how many runs have been written (i.e., how many times `finish_run` has been called). */
+  uint32_t num_runs();
+
+  /** Expose the stored runs as a buffer. */
+  UntrustedBufferRef<tuix::SortedRuns> output_buffer();
+
+  /**
+   * If there is only one run, expose it as as a RowWriter. This object retains ownership of the
+   * returned pointer.
+   */
+  RowWriter *as_row_writer();
+
+private:
+  RowWriter container;
+  std::vector<flatbuffers::Offset<tuix::EncryptedBlocks>> runs;
+};
+
+#endif

--- a/src/enclave/Enclave/Project.cpp
+++ b/src/enclave/Enclave/Project.cpp
@@ -1,21 +1,18 @@
 #include "Project.h"
 
 #include "ExpressionEvaluation.h"
+#include "FlatbuffersReaders.h"
+#include "FlatbuffersWriters.h"
 #include "common.h"
 
 void project(uint8_t *project_list, size_t project_list_length,
              uint8_t *input_rows, size_t input_rows_length,
              uint8_t **output_rows, size_t *output_rows_length) {
-  flatbuffers::Verifier v(project_list, project_list_length);
-  if (!v.VerifyBuffer<tuix::ProjectExpr>(nullptr)) {
-      throw std::runtime_error(
-          std::string("Corrupt ProjectExpr buffer of length ")
-          + std::to_string(project_list_length));
-  }
+  BufferRefView<tuix::ProjectExpr> project_list_buf(project_list, project_list_length);
+  project_list_buf.verify();
 
   // Create a vector of expression evaluators, one per output column
-  const tuix::ProjectExpr* project_expr =
-    flatbuffers::GetRoot<tuix::ProjectExpr>(project_list);
+  const tuix::ProjectExpr* project_expr = project_list_buf.root();
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> project_eval_list;
   for (auto it = project_expr->project_list()->begin();
        it != project_expr->project_list()->end();
@@ -23,8 +20,8 @@ void project(uint8_t *project_list, size_t project_list_length,
     project_eval_list.emplace_back(new FlatbuffersExpressionEvaluator(*it));
   }
 
-  EncryptedBlocksToRowReader r(input_rows, input_rows_length);
-  FlatbuffersRowWriter w;
+  RowReader r(BufferRefView<tuix::EncryptedBlocks>(input_rows, input_rows_length));
+  RowWriter w;
 
   std::vector<const tuix::Field *> out_fields(project_eval_list.size());
 
@@ -33,10 +30,8 @@ void project(uint8_t *project_list, size_t project_list_length,
     for (uint32_t j = 0; j < project_eval_list.size(); j++) {
       out_fields[j] = project_eval_list[j]->eval(row);
     }
-    w.write(out_fields);
+    w.append(out_fields);
   }
 
-  w.finish(w.write_encrypted_blocks());
-  *output_rows = w.output_buffer().release();
-  *output_rows_length = w.output_size();
+  w.output_buffer(output_rows, output_rows_length);
 }


### PR DESCRIPTION
The reader and writer interfaces for working with Flatbuffers rows were
inconsistent and poorly documented. This commit factors them out to separate
files and cleans up their interfaces and behavior.