### PR TITLE
 Implement non-foreign-key join

### DIFF
--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -2,6 +2,20 @@
 
 #include "Flatbuffers.h"
 
+std::string to_string(const tuix::Row *row) {
+  std::string s;
+  flatbuffers::uoffset_t num_fields = row->field_values()->size();
+  s.append("[");
+  for (flatbuffers::uoffset_t i = 0; i < num_fields; i++) {
+    s.append(to_string(row->field_values()->Get(i)));
+    if (i + 1 < num_fields) {
+      s.append(",");
+    }
+  }
+  s.append("]");
+  return s;
+}
+
 std::string to_string(const Date &date) {
   uint64_t seconds_per_day = 60 * 60 * 24L;
   uint64_t secs = date.days_since_epoch * seconds_per_day;

--- a/src/enclave/Enclave/Flatbuffers.h
+++ b/src/enclave/Enclave/Flatbuffers.h
@@ -88,6 +88,7 @@ public:
   int32_t days_since_epoch;
 };
 
+std::string to_string(const tuix::Row *row);
 std::string to_string(const Date &date);
 std::string to_string(const tuix::Field *f);
 std::string to_string(const tuix::BooleanField *f);

--- a/src/enclave/Enclave/Join.cpp
+++ b/src/enclave/Enclave/Join.cpp
@@ -13,11 +13,27 @@ void scan_collect_last_primary(
   FlatbuffersJoinExprEvaluator join_expr_eval(join_expr, join_expr_length);
   RowReader r(BufferRefView<tuix::EncryptedBlocks>(input_rows, input_rows_length));
   RowWriter w;
+
+  FlatbuffersTemporaryRow last_primary;
+
+  // Accumulate all primary table rows from the same group as the last primary row into `w`.
+  //
+  // Because our distributed sorting algorithm uses range partitioning over the join keys, all
+  // primary rows belonging to the same group will be colocated in the same partition. (The
+  // corresponding foreign rows may be in the same partition or the next partition.) Therefore it is
+  // sufficient to send primary rows at most one partition forward.
   while (r.has_next()) {
     const tuix::Row *row = r.next();
     if (join_expr_eval.is_primary(row)) {
-      w.clear();
+      if (!last_primary.get() || !join_expr_eval.is_same_group(last_primary.get(), row)) {
+        w.clear();
+        last_primary.set(row);
+      }
+
       w.append(row);
+    } else {
+      w.clear();
+      last_primary.set(nullptr);
     }
   }
 
@@ -35,28 +51,49 @@ void non_oblivious_sort_merge_join(
   RowReader j(BufferRefView<tuix::EncryptedBlocks>(join_row, join_row_length));
   RowWriter w;
 
-  if (j.num_rows() > 1) {
-    throw std::runtime_error(
-      std::string("Incorrect number of join rows passed: expected 0 or 1, got ")
-      + std::to_string(j.num_rows()));
+  RowWriter primary_group;
+  FlatbuffersTemporaryRow last_primary_of_group;
+  while (j.has_next()) {
+    const tuix::Row *row = j.next();
+    primary_group.append(row);
+    last_primary_of_group.set(row);
   }
-
-  FlatbuffersTemporaryRow primary(j.has_next() ? j.next() : nullptr);
 
   while (r.has_next()) {
     const tuix::Row *current = r.next();
 
     if (join_expr_eval.is_primary(current)) {
-      if (primary.get() && join_expr_eval.is_same_group(primary.get(), current)) {
-        throw std::runtime_error(
-          "non_oblivious_sort_merge_join - primary table uniqueness constraint violation: "
-          "multiple rows from the primary table had the same join attribute");
+      if (last_primary_of_group.get()
+          && join_expr_eval.is_same_group(last_primary_of_group.get(), current)) {
+        // Add this primary row to the current group
+        primary_group.append(current);
+        last_primary_of_group.set(current);
+      } else {
+        // Advance to a new group
+        primary_group.clear();
+        primary_group.append(current);
+        last_primary_of_group.set(current);
       }
-      // Advance to a new join attribute
-      primary.set(current);
     } else {
-      if (primary.get() != nullptr && join_expr_eval.is_same_group(primary.get(), current)) {
-        w.append(primary.get(), current);
+      // Output the joined rows resulting from this foreign row
+      if (last_primary_of_group.get()
+          && join_expr_eval.is_same_group(last_primary_of_group.get(), current)) {
+        auto primary_group_buffer = primary_group.output_buffer();
+        RowReader primary_group_reader(primary_group_buffer.view());
+        while (primary_group_reader.has_next()) {
+          const tuix::Row *primary = primary_group_reader.next();
+
+          if (!join_expr_eval.is_same_group(primary, current)) {
+            throw std::runtime_error(
+              std::string("Invariant violation: rows of primary_group "
+                          "are not of the same group: ")
+              + to_string(primary)
+              + std::string(" vs ")
+              + to_string(current));
+          }
+
+          w.append(primary, current);
+        }
       }
     }
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -556,4 +556,16 @@ class OpaqueMultiplePartitionSuite extends OpaqueOperatorTests {
     val f = makePartitionedDF(f_data, securityLevel, numPartitions + 1, "fk", "x", "y")
     p.join(f, $"pk" === $"fk").collect.toSet
   }
+
+  testAgainstSpark("non-foreign-key join with high skew") { securityLevel =>
+    // This test is intended to ensure that primary groups are never split across multiple
+    // partitions, which would break our implementation of non-foreign-key join.
+
+    val p_data = for (i <- 1 to 128) yield (i, 1)
+    val f_data = for (i <- 1 to 128) yield (i, 1)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2")
+    p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
+  }
+
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -263,6 +263,14 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     p.join(f, $"pk" === $"fk").collect.toSet
   }
 
+  testAgainstSpark("non-foreign-key join") { securityLevel =>
+    val p_data = for (i <- 1 to 128) yield (i, (i % 16).toString, i * 10)
+    val f_data = for (i <- 1 to 256 - 128) yield (i, (i % 16).toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+    p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
+  }
+
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
     case 1 => "B"


### PR DESCRIPTION
Non-foreign-key join requires the following changes:

1. During the `scan_collect_last_primary` preprocessing phase, we send all
primary rows from the last group of each partition to the next partition rather
than just the last primary row.

2. During the main join phase, when handling a foreign row, we loop over all
primary rows from the current group.

We only need to send primary rows at most one partition forward because our
distributed sorting algorithm uses range partitioning over the join keys, so all
primary rows belonging to the same group will be colocated in the same
partition. (The corresponding foreign rows may be in the same partition or the
next partition.)

Fixes #40.