### PR TITLE
Add logistic regression benchmark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ sparkVersion := "2.4.0"
 
 sparkComponents ++= Seq("core", "sql", "catalyst")
 
+libraryDependencies += "org.scalanlp" %% "breeze" % "0.13.2"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 
 val flatbuffersVersion = "1.7.0"

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ sparkComponents ++= Seq("core", "sql", "catalyst")
 
 libraryDependencies += "org.scalanlp" %% "breeze" % "0.13.2"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
 val flatbuffersVersion = "1.7.0"
 

--- a/src/flatbuffers/Expr.fbs
+++ b/src/flatbuffers/Expr.fbs
@@ -26,6 +26,10 @@ union ExprUnion {
     If,
     Cast,
     Year,
+    VectorAdd,
+    VectorMultiply,
+    DotProduct,
+    Exp,
 }
 
 table Expr {
@@ -133,4 +137,25 @@ table If {
 // Date expressions
 table Year {
     child:Expr;
+}
+
+// Math expressions
+table Exp {
+    child:Expr;
+}
+
+// Opaque UDFs
+table VectorAdd {
+    left:Expr;
+    right:Expr;
+}
+
+table VectorMultiply {
+    left:Expr;
+    right:Expr;
+}
+
+table DotProduct {
+    left:Expr;
+    right:Expr;
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/LogisticRegression.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/LogisticRegression.scala
@@ -78,7 +78,6 @@ object LogisticRegression {
       val w = DenseVector.fill(D) {2 * rand.nextDouble - 1}
 
       for (i <- 1 to ITERATIONS) {
-        println(s"On iteration $i")
         val gradient = points
           .select(
             vectormultiply(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/LogisticRegression.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/LogisticRegression.scala
@@ -19,7 +19,7 @@ package edu.berkeley.cs.rise.opaque.benchmark
 
 import java.util.Random
 
-import breeze.linalg.{DenseVector, Vector}
+import breeze.linalg.DenseVector
 import edu.berkeley.cs.rise.opaque.Utils
 import edu.berkeley.cs.rise.opaque.expressions.DotProduct.dot
 import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply.vectormultiply
@@ -59,7 +59,7 @@ object LogisticRegression {
   }
 
   def train(spark: SparkSession, securityLevel: SecurityLevel, N: Int, numPartitions: Int)
-    : Vector[Double] = {
+    : Array[Double] = {
     import spark.implicits._
     val rand = new Random(42)
     val D = 10
@@ -89,7 +89,7 @@ object LogisticRegression {
         w -= new DenseVector(gradient)
       }
 
-      w
+      w.toArray
     }
   }
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/LogisticRegression.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/LogisticRegression.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque.benchmark
+
+import java.util.Random
+
+import breeze.linalg.{DenseVector, Vector}
+import edu.berkeley.cs.rise.opaque.Utils
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+object LogisticRegression {
+
+  def data(
+      spark: SparkSession,
+      securityLevel: SecurityLevel,
+      numPartitions: Int,
+      rand: Random,
+      N: Int,
+      D: Int,
+      R: Double)
+    : DataFrame = {
+    def generatePoint(i: Int): (Array[Double], Double) = {
+      val y = if (i % 2 == 0) -1 else 1
+      val x = Array.fill(D) {rand.nextGaussian + y * R}
+      (x, y)
+    }
+
+    val data = Array.tabulate(N)(generatePoint)
+    val schema = StructType(Seq(
+      StructField("x", DataTypes.createArrayType(DoubleType)),
+      StructField("y", DoubleType)))
+
+    securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+  }
+
+  def train(spark: SparkSession, securityLevel: SecurityLevel, N: Int, numPartitions: Int)
+    : Vector[Double] = {
+    import spark.implicits._
+    val rand = new Random(42)
+    val D = 10
+    val ITERATIONS = 5
+
+    val dot = udf((a: Seq[Double], b: Seq[Double]) =>
+      new DenseVector(a.toArray).dot(new DenseVector(b.toArray)))
+    val vectormultiply = udf((v: Seq[Double], c: Double) =>
+      (new DenseVector(v.toArray) * c).toArray)
+    val vectorsum = new VectorSum
+
+    val points = Utils.ensureCached(data(spark, securityLevel, numPartitions, rand, N, D, 0.7))
+    Utils.time("Generate logistic regression data") { Utils.force(points) }
+    Utils.timeBenchmark(
+      "distributed" -> (numPartitions > 1),
+      "query" -> "logistic regression",
+      "system" -> securityLevel.name,
+      "N" -> N) {
+
+      val w = DenseVector.fill(D) {2 * rand.nextDouble - 1}
+
+      for (i <- 1 to ITERATIONS) {
+        println(s"On iteration $i")
+        val gradient = points
+          .select(
+            (vectormultiply(
+              $"x",
+              (lit(1.0) / (lit(1.0) + exp(-$"y" * dot(lit(w.toArray), $"x"))) - lit(1.0)) * $"y"))
+              .as("v"))
+          .groupBy().agg(vectorsum($"v"))
+          .first().getSeq[Double](0).toArray
+        w -= new DenseVector(gradient)
+      }
+
+      w
+    }
+  }
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/VectorSum.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/VectorSum.scala
@@ -1,0 +1,61 @@
+package edu.berkeley.cs.rise.opaque.benchmark
+
+import org.apache.spark.sql.expressions.MutableAggregationBuffer
+import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+class VectorSum extends UserDefinedAggregateFunction {
+  private def addArray(agg: Array[Double], arr: Array[Double]): Unit = {
+    var i = 0
+    while (i < arr.length) {
+      agg(i) = agg(i) + arr(i)
+      i += 1
+    }
+  }
+
+  // function to determine if the current array size is large enough to old the record size.
+  // if not, it will resize the array and return a new copy
+  private def ensureArraySize(agg: Array[Double], size: Int): Array[Double] = {
+    if(size > agg.length) {
+      val newAgg = new Array[Double](size)
+      Array.copy(agg, 0, newAgg, 0, agg.length)
+      newAgg
+    } else {
+      agg
+    }
+  }
+
+  override def inputSchema: StructType =
+    new StructType().add("arr", ArrayType(DoubleType, false))
+
+  override def bufferSchema: StructType =
+    new StructType().add("arr", ArrayType(DoubleType, false))
+
+  override def dataType: DataType = ArrayType(DoubleType, false)
+
+  override def deterministic: Boolean = true
+
+  override def initialize(buffer: MutableAggregationBuffer): Unit = {
+    buffer.update(0, Array[Double]())
+  }
+
+  override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+    if(!input.isNullAt(0)) {
+      val arr = input.getAs[Seq[Double]](0)
+      val agg: Array[Double] = ensureArraySize(buffer.getSeq[Double](0).toArray, arr.size)
+      addArray(agg, arr.toArray)
+      buffer.update(0, agg.toSeq)
+    }
+  }
+
+  def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+    val agg2: Array[Double] = buffer2.getSeq[Double](0).toArray
+    val agg1: Array[Double] = ensureArraySize(buffer1.getSeq[Double](0).toArray, agg2.length)
+    addArray(agg1, agg2)
+    buffer1.update(0, agg1.toSeq)
+  }
+
+  def evaluate(buffer: Row): Array[Double] =
+    buffer.getSeq[Double](0).toArray
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/DotProduct.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/DotProduct.scala
@@ -1,0 +1,32 @@
+package edu.berkeley.cs.rise.opaque.expressions
+
+import breeze.linalg.DenseVector
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.BinaryOperator
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.NullIntolerant
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.DoubleType
+
+object DotProduct {
+  def dot(v1: Column, v2: Column): Column =
+    new Column(DotProduct(v1.expr, v2.expr))
+}
+
+case class DotProduct(left: Expression, right: Expression)
+    extends BinaryOperator with NullIntolerant with CodegenFallback {
+
+  override def dataType: DataType = DoubleType
+
+  override def inputType = DataTypes.createArrayType(DoubleType)
+
+  override def symbol: String = "dot"
+
+  override def sqlOperator: String = "$dot"
+
+  protected override def nullSafeEval(input1: Any, input2: Any): Any =
+    new DenseVector(input1.asInstanceOf[Seq[Double]].toArray)
+      .dot(new DenseVector(input2.asInstanceOf[Seq[Double]].toArray))
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorAdd.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorAdd.scala
@@ -11,25 +11,25 @@ import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.DoubleType
 
-object DotProduct {
-  def dot(v1: Column, v2: Column): Column =
-    new Column(DotProduct(v1.expr, v2.expr))
+object VectorAdd {
+  def vectoradd(v1: Column, v2: Column): Column =
+    new Column(VectorAdd(v1.expr, v2.expr))
 }
 
-case class DotProduct(left: Expression, right: Expression)
+case class VectorAdd(left: Expression, right: Expression)
     extends BinaryOperator with NullIntolerant with CodegenFallback {
 
-  override def dataType: DataType = DoubleType
+  override def dataType: DataType = left.dataType
 
   override def inputType = DataTypes.createArrayType(DoubleType)
 
-  override def symbol: String = "dot"
+  override def symbol: String = "+"
 
-  override def sqlOperator: String = "$dot"
+  override def sqlOperator: String = "$plus"
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Double = {
+  protected override def nullSafeEval(input1: Any, input2: Any): ArrayData = {
     val v1 = input1.asInstanceOf[ArrayData].toDoubleArray
     val v2 = input2.asInstanceOf[ArrayData].toDoubleArray
-    new DenseVector(v1).dot(new DenseVector(v2))
+    ArrayData.toArrayData ((new DenseVector(v1) + new DenseVector(v2)).toArray)
   }
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorMultiply.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorMultiply.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.NullIntolerant
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.DoubleType
@@ -23,7 +24,9 @@ case class VectorMultiply(left: Expression, right: Expression)
 
   override def inputTypes = Seq(DataTypes.createArrayType(DoubleType), DoubleType)
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Any =
-    (new DenseVector(input1.asInstanceOf[Seq[Double]].toArray) * input2.asInstanceOf[Double])
-      .toArray
+  protected override def nullSafeEval(input1: Any, input2: Any): ArrayData = {
+    val v = input1.asInstanceOf[ArrayData].toDoubleArray
+    val c = input2.asInstanceOf[Double]
+    ArrayData.toArrayData((new DenseVector(v) * c).toArray)
+  }
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorMultiply.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorMultiply.scala
@@ -1,0 +1,29 @@
+package edu.berkeley.cs.rise.opaque.expressions
+
+import breeze.linalg.DenseVector
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.BinaryExpression
+import org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.NullIntolerant
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.DoubleType
+
+object VectorMultiply {
+  def vectormultiply(v: Column, c: Column): Column =
+    new Column(VectorMultiply(v.expr, c.expr))
+}
+
+case class VectorMultiply(left: Expression, right: Expression)
+    extends BinaryExpression with NullIntolerant with CodegenFallback with ExpectsInputTypes {
+
+  override def dataType: DataType = left.dataType
+
+  override def inputTypes = Seq(DataTypes.createArrayType(DoubleType), DoubleType)
+
+  protected override def nullSafeEval(input1: Any, input2: Any): Any =
+    (new DenseVector(input1.asInstanceOf[Seq[Double]].toArray) * input2.asInstanceOf[Double])
+      .toArray
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorSum.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorSum.scala
@@ -1,9 +1,27 @@
-package edu.berkeley.cs.rise.opaque.benchmark
+package edu.berkeley.cs.rise.opaque.expressions
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.BinaryOperator
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.NullIntolerant
+import org.apache.spark.sql.catalyst.expressions.Unevaluable
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
 import org.apache.spark.sql.expressions.MutableAggregationBuffer
 import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
+
+/** Placeholder expression for the vector sum operation, for Opaque internal use. */
+private[opaque] case class VectorAddExpr(left: Expression, right: Expression)
+    extends BinaryOperator with NullIntolerant with Unevaluable {
+  override def dataType: DataType = left.dataType
+
+  override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess
+
+  override def inputType = DataTypes.createArrayType(DoubleType)
+
+  override def symbol: String = "+"
+}
 
 class VectorSum extends UserDefinedAggregateFunction {
   private def addArray(agg: Array[Double], arr: Array[Double]): Unit = {

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorSum.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/VectorSum.scala
@@ -1,28 +1,15 @@
 package edu.berkeley.cs.rise.opaque.expressions
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.expressions.BinaryOperator
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.expressions.NullIntolerant
-import org.apache.spark.sql.catalyst.expressions.Unevaluable
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
 import org.apache.spark.sql.expressions.MutableAggregationBuffer
 import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
 import org.apache.spark.sql.types._
 
-/** Placeholder expression for the vector sum operation, for Opaque internal use. */
-private[opaque] case class VectorAddExpr(left: Expression, right: Expression)
-    extends BinaryOperator with NullIntolerant with Unevaluable {
-  override def dataType: DataType = left.dataType
-
-  override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess
-
-  override def inputType = DataTypes.createArrayType(DoubleType)
-
-  override def symbol: String = "+"
-}
-
+/**
+ * Spark SQL UDAF to enable elementwise summation of Array[Double].
+ *
+ * From https://gist.github.com/mrchristine/4f77885dab668a39c063b44b4ae71582.
+ */
 class VectorSum extends UserDefinedAggregateFunction {
   private def addArray(agg: Array[Double], arr: Array[Double]): Unit = {
     var i = 0

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.CalendarInterval
+import org.scalactic.Equality
 import org.scalactic.TolerantNumerics
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
@@ -64,9 +65,30 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     spark.stop()
   }
 
-  def testAgainstSpark(name: String)(f: SecurityLevel => Any): Unit = {
+  private def equalityToArrayEquality[A : Equality](): Equality[Array[A]] = {
+    new Equality[Array[A]] {
+      def areEqual(a: Array[A], b: Any): Boolean = {
+        b match {
+          case b: Array[_] =>
+            (a.length == b.length
+              && a.zip(b).forall {
+                case (x, y) => implicitly[Equality[A]].areEqual(x, y)
+              })
+          case _ => false
+        }
+      }
+      override def toString: String = s"TolerantArrayEquality"
+    }
+  }
+
+  // Modify the behavior of === for Double and Array[Double] to use a numeric tolerance
+  implicit val tolerantDoubleEquality = TolerantNumerics.tolerantDoubleEquality(1e-6)
+  implicit val tolerantDoubleArrayEquality = equalityToArrayEquality[Double]
+
+  def testAgainstSpark[A : Equality](name: String)(f: SecurityLevel => A): Unit = {
     test(name + " - encrypted") {
-      implicit val tolerant = TolerantNumerics.tolerantDoubleEquality(0.00001)
+      // The === operator uses implicitly[Equality[A]], which compares Double and Array[Double]
+      // using the numeric tolerance specified above
       assert(f(Encrypted) === f(Insecure))
     }
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -484,6 +484,10 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     answer
   }
 
+  testAgainstSpark("logistic regression") { securityLevel =>
+    LogisticRegression.train(spark, securityLevel, 1000, numPartitions)
+  }
+
   testOpaqueOnly("pagerank") { securityLevel =>
     PageRank.run(spark, securityLevel, "256", numPartitions)
   }


### PR DESCRIPTION
This PR adds the following expressions and UDAFs to Opaque:

- Exp (expression - exponential function)
- VectorAdd (expression - adds two vectors elementwise, used to implement the VectorSum UDAF)
- VectorMultiply (expression - multiplies a vector by a scalar)
- DotProduct (expression - computes the dot product of two vectors)
- UnaryMinus (expression - implemented in terms of Subtract)
- VectorSum (UDAF - sums vectors elementwise)

It then implements logistic regression in Spark SQL using these expressions and UDAFs. The implementation follows the [Spark example](https://github.com/apache/spark/blob/b8dd84b9e4690efa9773f73787e19a4d60257e5e/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala).

Also, it adds the ability to compare Array[Double] using a numeric tolerance in OpaqueOperatorTests.