### PR TITLE
Enable running benchmarks without spark-submit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,19 @@ concurrentRestrictions in Global := Seq(
   Tags.limit(Tags.Test, 1))
 
 fork in Test := true
+fork in run := true
 
 javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m")
+javaOptions in run ++= Seq(
+  "-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-Dspark.master=local[1]")
+
+// Include Spark dependency for `build/sbt run`, though it is marked as "provided" for use with
+// spark-submit. From
+// https://github.com/sbt/sbt-assembly/blob/4a211b329bf31d9d5f0fae67ea4252896d8a4a4d/README.md
+run in Compile := Defaults.runTask(
+  fullClasspath in Compile,
+  mainClass in (Compile, run),
+  runner in (Compile, run)).evaluated
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -2,5 +2,3 @@ log4j.logger.org.apache.spark=WARN
 log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.apache.spark.executor.Executor=ERROR
 log4j.logger.org.apache.spark.scheduler.TaskSetManager=ERROR
-
-log4j.logger.edu.berkeley.cs.rise.opaque=WARN

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/Benchmark.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/Benchmark.scala
@@ -20,6 +20,14 @@ package edu.berkeley.cs.rise.opaque.benchmark
 import edu.berkeley.cs.rise.opaque.Utils
 import org.apache.spark.sql.SparkSession
 
+/**
+ * Convenient runner for benchmarks.
+ *
+ * To run locally, use
+ * `$OPAQUE_HOME/build/sbt 'run edu.berkeley.cs.rise.opaque.benchmark.Benchmark'`.
+ *
+ * To run on a cluster, use `$SPARK_HOME/bin/spark-submit` with appropriate arguments.
+ */
 object Benchmark {
   def dataDir: String = {
     if (System.getenv("SPARKSGX_DATA_DIR") == null) {
@@ -37,26 +45,13 @@ object Benchmark {
     // val numPartitions =
     //   if (spark.sparkContext.isLocal) 1 else spark.sparkContext.defaultParallelism
 
-    val numPartitions = 5
-
     // Warmup
-    BigDataBenchmark.q2(spark, Encrypted, "tiny", numPartitions)
-    BigDataBenchmark.q2(spark, Encrypted, "tiny", numPartitions)
+    LogisticRegression.train(spark, Encrypted, 1000, 1)
+    LogisticRegression.train(spark, Encrypted, 1000, 1)
 
     // Run
-    BigDataBenchmark.q1(spark, Insecure, "1million", numPartitions)
-    BigDataBenchmark.q1(spark, Encrypted, "1million", numPartitions)
-
-    BigDataBenchmark.q2(spark, Insecure, "1million", numPartitions)
-    BigDataBenchmark.q2(spark, Encrypted, "1million", numPartitions)
-
-    BigDataBenchmark.q3(spark, Insecure, "1million", numPartitions)
-    BigDataBenchmark.q3(spark, Encrypted, "1million", numPartitions)
-
-    LeastSquares.query(spark, Insecure, "1000000", numPartitions)
-    LeastSquares.query(spark, Encrypted, "1000000", numPartitions)
-
-    Thread.sleep(10000000)
+    LogisticRegression.train(spark, Insecure, 100000, 1)
+    LogisticRegression.train(spark, Encrypted, 100000, 1)
 
     spark.stop()
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -56,8 +56,6 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   import testImplicits._
 
   override def beforeAll(): Unit = {
-    LogManager.getLogger("edu.berkeley.cs.rise.opaque").setLevel(Level.WARN)
-    LogManager.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(Level.ERROR)
     Utils.initSQLContext(spark.sqlContext)
   }
 


### PR DESCRIPTION
This PR enables running Benchmark.scala from within the Opaque repository without needing a separate Spark installation: `$OPAQUE_HOME/build/sbt 'run edu.berkeley.cs.rise.opaque.benchmark.Benchmark'`.

This requires SBT configuration to add Spark back to the classpath for `run` even though it is marked as `provided` for use with spark-submit. The Spark master is also be set to `local[1]` by default using Java properties, and a log4j.properties file is provided.