### PR TITLE
Add k-means benchmark

### DIFF
--- a/src/flatbuffers/Expr.fbs
+++ b/src/flatbuffers/Expr.fbs
@@ -30,6 +30,7 @@ union ExprUnion {
     VectorMultiply,
     DotProduct,
     Exp,
+    ClosestPoint,
 }
 
 table Expr {
@@ -156,6 +157,11 @@ table VectorMultiply {
 }
 
 table DotProduct {
+    left:Expr;
+    right:Expr;
+}
+
+table ClosestPoint {
     left:Expr;
     right:Expr;
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -98,6 +98,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import edu.berkeley.cs.rise.opaque.execution.Block
 import edu.berkeley.cs.rise.opaque.execution.OpaqueOperatorExec
 import edu.berkeley.cs.rise.opaque.execution.SGXEnclave
+import edu.berkeley.cs.rise.opaque.expressions.ClosestPoint
 import edu.berkeley.cs.rise.opaque.expressions.DotProduct
 import edu.berkeley.cs.rise.opaque.expressions.VectorAdd
 import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply
@@ -951,6 +952,13 @@ object Utils extends Logging {
             builder,
             tuix.ExprUnion.DotProduct,
             tuix.DotProduct.createDotProduct(
+              builder, leftOffset, rightOffset))
+
+        case (ClosestPoint(left, right), Seq(leftOffset, rightOffset)) =>
+          tuix.Expr.createExpr(
+            builder,
+            tuix.ExprUnion.ClosestPoint,
+            tuix.ClosestPoint.createClosestPoint(
               builder, leftOffset, rightOffset))
       }
     }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/KMeans.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/KMeans.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque.benchmark
+
+import java.util.Random
+
+import breeze.linalg.DenseVector
+import breeze.linalg.squaredDistance
+import edu.berkeley.cs.rise.opaque.Utils
+import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply.vectormultiply
+import edu.berkeley.cs.rise.opaque.expressions.VectorSum
+import edu.berkeley.cs.rise.opaque.expressions.ClosestPoint.closestPoint
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+object KMeans {
+
+  def data(
+      spark: SparkSession,
+      securityLevel: SecurityLevel,
+      numPartitions: Int,
+      rand: Random,
+      N: Int,
+      D: Int)
+    : DataFrame = {
+    def generatePoint(): Array[Double] = {
+      Array.fill(D) {rand.nextGaussian}
+    }
+
+    val data = Array.fill(N)(Row(generatePoint()))
+    val schema = StructType(Seq(
+      StructField("p", DataTypes.createArrayType(DoubleType))))
+
+    securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data, numPartitions),
+        schema))
+  }
+
+  def train(
+      spark: SparkSession, securityLevel: SecurityLevel, numPartitions: Int,
+      N: Int, D: Int, K: Int, convergeDist: Double)
+    : Array[Array[Double]] = {
+    import spark.implicits._
+    val rand = new Random(42)
+    val vectorsum = new VectorSum
+
+    val points = Utils.ensureCached(data(spark, securityLevel, numPartitions, rand, N, D))
+    Utils.time("Generate k-means data") { Utils.force(points) }
+
+    Utils.timeBenchmark(
+      "distributed" -> (numPartitions > 1),
+      "query" -> "k-means",
+      "system" -> securityLevel.name,
+      "N" -> N) {
+
+      // Sample k random points.
+      // TODO: Assumes points are already permuted randomly.
+      var centroids = points.take(K).map(_.getSeq[Double](0).toArray)
+      var tempDist = 1.0
+
+      while (tempDist > convergeDist) {
+        val newCentroids = points
+          .select(
+            closestPoint($"p", lit(centroids)).as("oldCentroid"),
+            $"p".as("centroidPartialSum"),
+            lit(1).as("centroidPartialCount"))
+          .groupBy($"oldCentroid")
+          .agg(
+            vectorsum($"centroidPartialSum").as("centroidSum"),
+            sum($"centroidPartialCount").as("centroidCount"))
+          .select(
+            $"oldCentroid",
+            vectormultiply($"centroidSum", (lit(1.0) / $"centroidCount")).as("newCentroid"))
+          .collect
+
+        tempDist = 0.0
+        for (row <- newCentroids) {
+          tempDist += squaredDistance(
+            new DenseVector(row.getSeq[Double](0).toArray),
+            new DenseVector(row.getSeq[Double](1).toArray))
+        }
+
+        centroids = newCentroids.map(_.getSeq[Double](1).toArray)
+      }
+
+
+      centroids
+    }
+  }
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/KMeans.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/KMeans.scala
@@ -22,9 +22,9 @@ import java.util.Random
 import breeze.linalg.DenseVector
 import breeze.linalg.squaredDistance
 import edu.berkeley.cs.rise.opaque.Utils
+import edu.berkeley.cs.rise.opaque.expressions.ClosestPoint.closestPoint
 import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply.vectormultiply
 import edu.berkeley.cs.rise.opaque.expressions.VectorSum
-import edu.berkeley.cs.rise.opaque.expressions.ClosestPoint.closestPoint
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/ClosestPoint.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/ClosestPoint.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.BinaryExpression
 import org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.ExpressionDescription
 import org.apache.spark.sql.catalyst.expressions.NullIntolerant
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.ArrayData
@@ -18,6 +19,19 @@ object ClosestPoint {
     new Column(ClosestPoint(point.expr, centroids.expr))
 }
 
+@ExpressionDescription(
+  usage = """
+    _FUNC_(point, centroids) - Given an `Array[Double]` and an `Array[Array[Double]]`, finds the
+      point in the latter closest to the former using squared distance.
+  """,
+  arguments = """
+    Arguments:
+      * point - list of coordinates representing a point
+      * centroids - list of lists of coordinates, each representing a point
+  """)
+/**
+ *
+ */
 case class ClosestPoint(left: Expression, right: Expression)
     extends BinaryExpression with NullIntolerant with CodegenFallback with ExpectsInputTypes {
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/ClosestPoint.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/expressions/ClosestPoint.scala
@@ -1,0 +1,49 @@
+package edu.berkeley.cs.rise.opaque.expressions
+
+import breeze.linalg.DenseVector
+import breeze.linalg.squaredDistance
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.BinaryExpression
+import org.apache.spark.sql.catalyst.expressions.ExpectsInputTypes
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.NullIntolerant
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.DoubleType
+
+object ClosestPoint {
+  def closestPoint(point: Column, centroids: Column): Column =
+    new Column(ClosestPoint(point.expr, centroids.expr))
+}
+
+case class ClosestPoint(left: Expression, right: Expression)
+    extends BinaryExpression with NullIntolerant with CodegenFallback with ExpectsInputTypes {
+
+  override def dataType: DataType = left.dataType
+
+  override def inputTypes = Seq(
+    DataTypes.createArrayType(DoubleType),
+    DataTypes.createArrayType(DataTypes.createArrayType(DoubleType)))
+
+  protected override def nullSafeEval(input1: Any, input2: Any): ArrayData = {
+    val point = new DenseVector(input1.asInstanceOf[ArrayData].toDoubleArray)
+    val centroids = input2.asInstanceOf[ArrayData]
+      .toArray[ArrayData](DataTypes.createArrayType(DoubleType))
+      .map(centroid => new DenseVector(centroid.toDoubleArray))
+
+    var bestIndex = 0
+    var bestDist = Double.PositiveInfinity
+
+    for (i <- 0 until centroids.length) {
+      val tempDist = squaredDistance(point, centroids(i))
+      if (tempDist < bestDist) {
+        bestDist = tempDist
+        bestIndex = i
+      }
+    }
+
+    ArrayData.toArrayData(centroids(bestIndex).toArray)
+  }
+}

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/logical/rules.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/logical/rules.scala
@@ -95,10 +95,6 @@ object ConvertToOpaqueOperators extends Rule[LogicalPlan] {
               child.asInstanceOf[OpaqueOperator]))
       }
 
-    // For now, just ignore limits. TODO: Implement Opaque operators for these
-    case p @ GlobalLimit(_, child) if isEncrypted(p) => child
-    case p @ LocalLimit(_, child) if isEncrypted(p) => child
-
     case p @ Union(Seq(left, right)) if isEncrypted(p) =>
       EncryptedUnion(left.asInstanceOf[OpaqueOperator], right.asInstanceOf[OpaqueOperator])
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -587,6 +587,11 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     LogisticRegression.train(spark, securityLevel, 1000, numPartitions)
   }
 
+  testAgainstSpark("k-means") { securityLevel =>
+    import scala.math.Ordering.Implicits.seqDerivedOrdering
+    KMeans.train(spark, securityLevel, numPartitions, 10, 2, 3, 0.01).map(_.toSeq).sorted
+  }
+
   testAgainstSpark("pagerank") { securityLevel =>
     PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
   }


### PR DESCRIPTION
This PR adds a k-means benchmark for Opaque following the [Spark example](https://github.com/apache/spark/blob/8bc304f97ee693b57f33fa6708eb63e2d641c609/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala).

It also adds the following features necessary for k-means:

- ClosestPoint expression: given an Array[Double] and an Array[Array[Double]], find the point in the latter closest to the former using squared distance.
- Ability to sort and group by Array[Double].
- Ability to take limits of Opaque DataFrames.