### PR TITLE
Implement join conditions

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -61,7 +61,12 @@ object OpaqueOperators extends Strategy {
             rightProjSchema.map(_.toAttribute),
             (leftProjSchema ++ rightProjSchema).map(_.toAttribute),
             sorted)
-          EncryptedProjectExec(dropTags(left.output, right.output), joined) :: Nil
+          val tagsDropped = EncryptedProjectExec(dropTags(left.output, right.output), joined)
+          val filtered = condition match {
+            case Some(condition) => EncryptedFilterExec(condition, tagsDropped)
+            case None => tagsDropped
+          }
+          filtered :: Nil
         case _ => Nil
       }
 


### PR DESCRIPTION
Spark SQL sometimes tries to combine a filter operator and a join operator by
putting the filter predicate into the join condition using the
PushPredicateThroughJoin rule. Opaque didn't fully implement join conditions, so
in this case the filter would get ignored. This commit implements join
conditions using an EncryptedFilter on the result of the join.