### PR TITLE
Document missing steps in remote attestation

### DIFF
--- a/src/enclave/Enclave/CMakeLists.txt
+++ b/src/enclave/Enclave/CMakeLists.txt
@@ -62,8 +62,8 @@ endif()
 target_link_libraries(enclave_trusted -Wl,--whole-archive "${Trts_Library_Path}" -Wl,--no-whole-archive -Wl,--start-group "${TSTDC_LIB}" "${TSTDCXX_LIB}"
   "${TKEY_EXCHANGE_LIB}" "${TCRYPTO_LIB}" "${Service_Library_Path}" -Wl,--end-group)
 
-// TODO: Use the user-generated private key to sign the enclave code.
-// Currently we use the sample private key from the Intel SGX SDK.
+# TODO: Use the user-generated private key to sign the enclave code.
+# Currently we use the sample private key from the Intel SGX SDK.
 add_custom_command(
   COMMAND ${SGX_ENCLAVE_SIGNER} sign -key "$ENV{SGX_SDK}/SampleCode/SampleEnclave/Enclave/Enclave_private.pem" -enclave $<TARGET_FILE:enclave_trusted> -out libenclave_trusted_signed.so -config ${CMAKE_CURRENT_SOURCE_DIR}/Enclave.config.xml
   DEPENDS enclave_trusted ${CMAKE_CURRENT_SOURCE_DIR}/Enclave.config.xml

--- a/src/enclave/Enclave/CMakeLists.txt
+++ b/src/enclave/Enclave/CMakeLists.txt
@@ -62,6 +62,8 @@ endif()
 target_link_libraries(enclave_trusted -Wl,--whole-archive "${Trts_Library_Path}" -Wl,--no-whole-archive -Wl,--start-group "${TSTDC_LIB}" "${TSTDCXX_LIB}"
   "${TKEY_EXCHANGE_LIB}" "${TCRYPTO_LIB}" "${Service_Library_Path}" -Wl,--end-group)
 
+// TODO: Use the user-generated private key to sign the enclave code.
+// Currently we use the sample private key from the Intel SGX SDK.
 add_custom_command(
   COMMAND ${SGX_ENCLAVE_SIGNER} sign -key "$ENV{SGX_SDK}/SampleCode/SampleEnclave/Enclave/Enclave_private.pem" -enclave $<TARGET_FILE:enclave_trusted> -out libenclave_trusted_signed.so -config ${CMAKE_CURRENT_SOURCE_DIR}/Enclave.config.xml
   DEPENDS enclave_trusted ${CMAKE_CURRENT_SOURCE_DIR}/Enclave.config.xml

--- a/src/enclave/ServiceProvider/ServiceProvider.cpp
+++ b/src/enclave/ServiceProvider/ServiceProvider.cpp
@@ -415,6 +415,15 @@ std::unique_ptr<ra_msg4_t> ServiceProvider::process_msg3(
       }
     }
   }
+  
+  // TODO:
+  // "Examine the enclave identity (MRSIGNER), security version and product ID.
+  // Examine the debug attribute and ensure it is not set (in a production environment).
+  // Decide whether or not to trust the enclave and, if provided, the PSE."
+  
+  // TODO:
+  // "Derive the session keys, SK and MK, that should be used to transmit
+  // future messages between the client and server during the session.
 
   // Generate msg4, containing the shared secret to be sent to the enclave.
   *msg4_size = sizeof(ra_msg4_t);


### PR DESCRIPTION
The current implementation of remote attestation verifies that the enclave is genuine, but it does not verify that (1) it is running the correct code, and (2) it is in release mode. (Launching enclaves in release mode requires a [Launch Enclave](https://github.com/intel/linux-sgx/blob/master/psw/ae/ref_le/ref_le.md) or a license from Intel.)

In addition, the enclave is currently not signed using the user's private key, but rather a sample key. This will need to change once we start validating the enclave's identity.

This PR adds TODOs to document these missing steps.